### PR TITLE
Only allow file codebase image uploads to be gif, jpeg or png

### DIFF
--- a/django/core/fs.py
+++ b/django/core/fs.py
@@ -36,7 +36,8 @@ def is_archive(path: str):
 
 def is_image(path: str):
     try:
-        return imghdr.what(path)
+        filetype = imghdr.what(path)
+        return filetype in ['jpeg', 'png', 'gif']
     except:
         return None
 

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -594,7 +594,7 @@ class Codebase(index.Indexed, ClusterableModel):
         if not is_image and images_only:
             logger.info('removing non image file: %s', path)
             path.unlink()
-            raise UnsupportedMediaType(fs.mimetypes.guess_type(name)[0], detail=f'{name} is not an image')
+            raise UnsupportedMediaType(fs.mimetypes.guess_type(name)[0], detail=f'{name} is not a valid file type. Must be a GIF, PNG, JPEG')
         image_metadata = {
             'name': name,
             'path': str(self.media_dir()),

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -22,6 +22,7 @@ django-webpack-loader==0.6.0
 djangorestframework==3.10.3
 djangorestframework-jsonapi==3.0.0
 djangorestframework-jwt==1.11.0
+Django<3.0.0
 elasticsearch-dsl>=6.0.0,<6.3.1
 elasticsearch>=6.0.0,<6.3.1
 html2text>=2016.9.19

--- a/frontend/src/components/upload.ts
+++ b/frontend/src/components/upload.ts
@@ -29,7 +29,8 @@ type UploadInfo = UploadSuccess | UploadProgress | UploadFailure;
         <div class="d-flex justify-content-between">
             <div>
                 <label :for="uploadId"><div class="btn btn-primary">Upload a file</div></label>
-                <input class="invisible" :id="uploadId" type="file" @change="handleFiles($event)">
+                <input class="invisible" :id="uploadId" type="file"
+                       @change="handleFiles($event)" :accept="acceptedFileTypes">
             </div>
             <div>
                 <button class="btn btn-danger" @click="clear">Remove all files</button>

--- a/frontend/src/pages/codebase/release/workflow.ts
+++ b/frontend/src/pages/codebase/release/workflow.ts
@@ -58,6 +58,7 @@ type CodebaseTabs = 'metadata' | 'media';
                                 <c-upload :uploadUrl="uploadUrl" title="Upload Media"
                                     instructions="Upload featured media files here. Images are displayed on the release detail page of every release"
                                     originalInstructions="Current media files" :originals="files" @doneUpload="getMediaFiles"
+                                    acceptedFileTypes="image/gif, image/jpeg, image/png"
                                     @deleteFile="deleteFile" @clear="clear">
                                 </c-upload>
                             </div>


### PR DESCRIPTION
Previously any image/* types were allowed.

Testing:

- tested client side filters in Safari, Chrome, Firefox. Filters don't work in Firefox
- server side now rejects any file type without gif, jpeg, png headers
- tests codebase file uploads to make sure they still work