### PR TITLE
style: assert same css for digests + conferences

### DIFF
--- a/django/home/templates/home/conference/list.jinja
+++ b/django/home/templates/home/conference/list.jinja
@@ -1,6 +1,32 @@
 {% extends "base.jinja" %}
 {% from "common.jinja" import breadcrumb, subnav %}
 
+{% block extra_css %}
+    {{ super() }}
+    <style type="text/css">
+        {# FIXME: consider moving to frontend css #}
+        .list-group {
+            font-family: arial, verdana;
+            font-size: 1.2em;
+        }
+
+        .list-group-item {
+            padding: 1rem;
+            margin-top: 1rem;
+            position: relative;
+            width: 100%;
+            min-width: 100%;
+            max-width: 100%;
+            border: black solid 0.15rem;
+            {#line-height: 125%;#}
+        }
+
+        a {
+            font-weight: bold;
+        }
+    </style>
+{% endblock %}
+
 {% block introduction %}
     <h1>CoMSES Virtual Conferences</h1>
 {% endblock %}
@@ -19,10 +45,10 @@
     <br/>
     <br/>
     <h2>Past Conferences</h2>
-    <ul class='list-group list-order'>
+    <ul class='list-group'>
         {% for conference in page.conferences() %}
             <a href='{{ conference.url }}'>
-            <li class='list-group-item box'>
+            <li class='list-group-item'>
                     <h5 class="conference-title">{{conference.title }}</h5>
                     <span class="conference-body">{{ conference.start_date|format_datetime }} &mdash; {{ conference.end_date|format_datetime }}</span>
             </li>

--- a/django/home/templates/home/conference/list.jinja
+++ b/django/home/templates/home/conference/list.jinja
@@ -48,7 +48,7 @@
     <ul class='list-group'>
         {% for conference in page.conferences() %}
             <a href='{{ conference.url }}'>
-            <li class='list-group-item'>
+            <li class='list-group-item list-group-item-action'>
                     <h5 class="conference-title">{{conference.title }}</h5>
                     <span class="conference-body">{{ conference.start_date|format_datetime }} &mdash; {{ conference.end_date|format_datetime }}</span>
             </li>

--- a/django/home/templates/home/digest.jinja
+++ b/django/home/templates/home/digest.jinja
@@ -21,6 +21,10 @@
             {#line-height: 125%;#}
         }
 
+        .campaign:hover {
+            background-color: #f7f7f7;
+        }
+
         a {
             font-weight: bold;
         }

--- a/django/home/templates/home/digest.jinja
+++ b/django/home/templates/home/digest.jinja
@@ -4,11 +4,26 @@
 {% block extra_css %}
     {{ super() }}
     <style type="text/css">
-{# FIXME: consider moving to frontend css #}
-<!--
-.display_archive {font-family: arial,verdana; font-size: 1.2em;}
-.campaign {line-height: 125%; margin: .3em;}
-//-->
+        {# FIXME: consider moving to frontend css #}
+        .display_archive {
+            font-family: arial, verdana;
+            font-size: 1.2em;
+        }
+
+        .campaign {
+            padding: 1rem;
+            margin-top: 1rem;
+            position: relative;
+            width: 100%;
+            min-width: 100%;
+            max-width: 100%;
+            border: black solid 0.15rem;
+            {#line-height: 125%;#}
+        }
+
+        a {
+            font-weight: bold;
+        }
     </style>
 {% endblock %}
 
@@ -20,25 +35,25 @@
     {{ breadcrumb([
     {'url': '/community/', 'text': 'Community'},
     {'text': 'CoMSES Digest Newsletter' }
-    ])
-    }}
+    ]) }}
     {{ subnav([
     {'url': '/community/', 'text': 'Community'},
     {'url': slugurl('conference'), 'text': 'Virtual Conferences'},
     {'url': url("home:digest"), 'text': 'CoMSES Digest', 'active': true},
-    ])
-    }}
+    ]) }}
     <div class='jumbotron'>
         <h1 class='display-5'>CoMSES Digest Newsletter</h1>
         <p class='pt-4 lead'>
-        The CoMSES Digest is a quarterly newsletter edited by <a href='/users/642/'>Dr. John Murphy</a> with relevant
-        comses.net community news - you can view all past issues in our archive below. CoMSES Net Full Members are
-        automatically signed up to receive the newsletter, but you can also <a href='http://eepurl.com/b8GCUv'>join our
-        mailing list</a> as a basic member.
+            The CoMSES Digest is a quarterly newsletter edited by <a href='/users/642/'>Dr. John Murphy</a> with
+            relevant
+            comses.net community news - you can view all past issues in our archive below. CoMSES Net Full Members are
+            automatically signed up to receive the newsletter, but you can also <a href='http://eepurl.com/b8GCUv'>join
+            our
+            mailing list</a> as a basic member.
         </p>
     </div>
-    <div class='content'>
-        <h2>Issues</h2>
+    <h2>Issues</h2>
+    <ul class='list-group list-order'>
         {% if mailchimp_js %}
             <script>
                 {{ mailchimp_js|safe }}
@@ -47,5 +62,5 @@
             <script src='{{ mailchimp_digest_archive_url }}'>
             </script>
         {% endif %}
-    </div>
+    </ul>
 {% endblock content %}

--- a/django/home/templates/home/digest.jinja
+++ b/django/home/templates/home/digest.jinja
@@ -17,7 +17,7 @@
             width: 100%;
             min-width: 100%;
             max-width: 100%;
-            border: black solid 0.15rem;
+            border: #dfdfdf solid 0.1rem;
             {#line-height: 125%;#}
         }
 


### PR DESCRIPTION
- use bootstrap list-group/list-group-item to style conference entries
- digest issues are generated via document.write and printed from mailchimp which leads to limitations in styling
- styled digest issues with equivalent css to bootstrap list-group/list-group-item styling
- may want to refactor generation and styling of digest issues in the future to use bootstrap so it's more maintainable and consistent

close #542 
