### PR TITLE
fix social connection issues

### DIFF
--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -188,12 +188,12 @@
             {% if csrf_input %}
                 {{ csrf_input }}
             {% endif %}
-            <button type="submit" title="{{ provider_name }}" class="btn btn-link p-0">
-                <i class='{{ provider_icon_class }}'></i> Connect your {{ provider_name }} account
+            <button type="submit" class="btn btn-link p-0">
+                <i class='{{ provider_icon_class }}'></i> Connect your {{ provider_display_name(provider_name) }} account
             </button>
         </form>
     {% else %}
-        No associated {{ provider_name }} account.
+        No associated {{ provider_display_name(provider_name) }} account.
     {% endif %}
 {% endwith %}
 {% endmacro %}

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -177,16 +177,21 @@
 {% endif %}
 {% endmacro %}
 
-{% macro render_social_profile_url(request, provider_name, profile_url, connect=False) %}
+{% macro render_social_profile_url(request, provider_name, profile_url, connect=False, csrf_input=None) %}
 {% with provider_icon_class="text-gray fab fa-" ~ provider_name %}
     {% if profile_url %}
         <a target='_blank' href='{{ profile_url }}'>
             <i class='{{ provider_icon_class }}'></i> {{ profile_url }}
         </a>
     {% elif connect %}
-        <a title="{{ provider_name }}" href="{{ provider_login_url(request, provider_name, process="connect") }}">
-             <i class='{{ provider_icon_class }}'></i> Connect your {{ provider_name }} account
-        </a>
+        <form action="{{ provider_login_url(request, provider_name, process='connect') }}" method="POST">
+            {% if csrf_input %}
+                {{ csrf_input }}
+            {% endif %}
+            <button type="submit" title="{{ provider_name }}" class="btn btn-link p-0">
+                <i class='{{ provider_icon_class }}'></i> Connect your {{ provider_name }} account
+            </button>
+        </form>
     {% else %}
         No associated {{ provider_name }} account.
     {% endif %}

--- a/django/core/jinja2/core/member_profiles/edit.jinja
+++ b/django/core/jinja2/core/member_profiles/edit.jinja
@@ -16,7 +16,7 @@
             </div>
         </div>
     </div>
-    <div id="app" data-user-pk='{{ object.user.id }}'></div>
+    <div id="app" data-user-pk="{{ object.user.id }}" data-connections-url="{{ url('socialaccount_connections') }}"></div>
 {% endblock %}
 
 {% block js %}

--- a/django/core/jinja2/socialaccount/connections.jinja
+++ b/django/core/jinja2/socialaccount/connections.jinja
@@ -19,7 +19,7 @@
         {{ csrf_input }}
 
         {% if form.non_field_errors() %}
-            <div id="errorMsg">{{ form.non_field_errors }}</div>
+            <div id="errorMsg">{{ form.non_field_errors() }}</div>
         {% endif %}
         <div class='form-group row'>
             <div class='col-10'>
@@ -47,10 +47,10 @@
     <div class='card-block'>
         <ul class="list-group list-group-flush">
             <li class='list-group-item'>
-                {{ render_social_profile_url(request, 'github', request.user.member_profile.github_url, connect=True) }}
+                {{ render_social_profile_url(request, 'github', request.user.member_profile.github_url, connect=True, csrf_input=csrf_input) }}
             </li>
             <li class='list-group-item'>
-                {{ render_social_profile_url(request, 'orcid', request.user.member_profile.orcid_url, connect=True) }}
+                {{ render_social_profile_url(request, 'orcid', request.user.member_profile.orcid_url, connect=True, csrf_input=csrf_input) }}
             </li>
         </ul>
     </div>

--- a/django/core/jinja2/socialaccount/connections.jinja
+++ b/django/core/jinja2/socialaccount/connections.jinja
@@ -37,6 +37,13 @@
             </div>
         </div>
         <button type="submit" class='btn btn-sm btn-primary'><span class='fa fa-trash'></span> Remove</button>
+        {% if form.accounts|length == 1 and not request.user.has_usable_password() %}     
+            <p class='text-muted'>
+                You must
+                <a href="{{ url('account_reset_password') }}">set a password</a>
+                before you can remove your only connected account.
+            </p>
+        {% endif %}
     </form>
 {% else %}
     <p>No connected accounts.</p>

--- a/django/core/jinja_config.py
+++ b/django/core/jinja_config.py
@@ -68,6 +68,7 @@ def environment(**options):
             "should_enable_discourse": should_enable_discourse,
             "is_production": is_production,
             "provider_login_url": provider_login_url,
+            "provider_display_name": provider_display_name,
             "get_choices_display": get_choices_display,
             "get_download_request_metadata": get_download_request_metadata,
             "markdown": markdown,
@@ -124,6 +125,15 @@ def provider_login_url(request, provider_id, **kwargs):
     if next_url:
         kwargs["next"] = next_url
     return provider.get_login_url(request, **kwargs)
+
+
+def provider_display_name(provider_name):
+    if provider_name == "github":
+        return "GitHub"
+    elif provider_name == "orcid":
+        return "ORCID"
+    else:
+        return provider_name
 
 
 def get_choices_display(selected_choice, choices):

--- a/frontend/src/components/profile/Edit.vue
+++ b/frontend/src/components/profile/Edit.vue
@@ -34,32 +34,28 @@
         <h3>Social Authentication and Membership</h3>
         <ul class="list-group">
           <li class="list-group-item">
-            <span v-if="orcid_url">
-              <a :href="orcid_url">
-                <span class="text-gray fab fa-orcid"></span> {{ orcid_url }}
-              </a>
-              <a title="Edit connection" :href="socialConnectionsURL">
+            <span v-if="github_url">
+              <a :href="github_url"><i class="text-gray fab fa-github"></i> {{ github_url }}</a>
+              <a :href="connectionsUrl" title="Manage connected GitHub account">
                 <i class="float-right fas fa-edit"></i>
               </a>
             </span>
             <span v-else>
-              <a title="github" :href="socialConnectionsURL">
-                <span class="text-gray fab fa-orcid"></span> Connect your ORCID account
+              <a :href="connectionsUrl">
+                <i class="text-gray fab fa-github"></i> Connect your GitHub account
               </a>
             </span>
           </li>
           <li class="list-group-item">
-            <span v-if="github_url">
-              <a :href="github_url">
-                <span class="text-gray fab fa-github"></span> {{ github_url }}
-              </a>
-              <a title="Edit connection" :href="socialConnectionsURL"
-                ><i class="float-right fas fa-edit"></i>
+            <span v-if="orcid_url">
+              <a :href="orcid_url"><i class="text-gray fab fa-orcid"></i> {{ orcid_url }}</a>
+              <a :href="connectionsUrl" title="Manage connected ORCID account">
+                <i class="float-right fas fa-edit"></i>
               </a>
             </span>
             <span v-else>
-              <a title="github" :href="socialConnectionsURL">
-                <span class="text-gray fab fa-github"></span> Connect your GitHub account
+              <a :href="connectionsUrl">
+                <i class="text-gray fab fa-orcid"></i> Connect your ORCID account
               </a>
             </span>
           </li>
@@ -250,6 +246,9 @@ export default class EditProfile extends createFormValidator(schema) {
   @Prop()
   public _pk: number | null;
 
+  @Prop()
+  public connectionsUrl: string;
+
   public initial_full_member: boolean = true;
 
   public industryOptions = [
@@ -310,10 +309,6 @@ export default class EditProfile extends createFormValidator(schema) {
 
   get uploadImageURL() {
     return `${window.location.href}picture/`;
-  }
-
-  get socialConnectionsURL() {
-    return "/accounts/social/connections";
   }
 }
 </script>

--- a/frontend/src/components/profile/Edit.vue
+++ b/frontend/src/components/profile/Edit.vue
@@ -35,12 +35,17 @@
         <ul class="list-group">
           <li class="list-group-item">
             <span v-if="orcid_url">
-              <a :href="orcid_url"><span class="text-gray fab fa-orcid"></span> {{ orcid_url }}</a>
+              <a :href="orcid_url">
+                <span class="text-gray fab fa-orcid"></span> {{ orcid_url }}
+              </a>
+              <a title="Edit connection" :href="socialConnectionsURL">
+                <i class="float-right fas fa-edit"></i>
+              </a>
             </span>
             <span v-else>
-              <a title="orcid" href="/accounts/orcid/login/?process=connect"
-                ><span class="text-gray fab fa-orcid"></span> Connect your ORCID account</a
-              >
+              <a title="github" :href="socialConnectionsURL">
+                <span class="text-gray fab fa-orcid"></span> Connect your ORCID account
+              </a>
             </span>
           </li>
           <li class="list-group-item">
@@ -48,9 +53,12 @@
               <a :href="github_url">
                 <span class="text-gray fab fa-github"></span> {{ github_url }}
               </a>
+              <a title="Edit connection" :href="socialConnectionsURL"
+                ><i class="float-right fas fa-edit"></i>
+              </a>
             </span>
             <span v-else>
-              <a title="github" href="/accounts/github/login/?process=connect">
+              <a title="github" :href="socialConnectionsURL">
                 <span class="text-gray fab fa-github"></span> Connect your GitHub account
               </a>
             </span>
@@ -302,6 +310,10 @@ export default class EditProfile extends createFormValidator(schema) {
 
   get uploadImageURL() {
     return `${window.location.href}picture/`;
+  }
+
+  get socialConnectionsURL() {
+    return "/accounts/social/connections";
   }
 }
 </script>

--- a/frontend/src/pages/profile/index.ts
+++ b/frontend/src/pages/profile/index.ts
@@ -4,7 +4,8 @@ import EditProfile from "@/components/profile/Edit.vue";
 function extractParams() {
   const el = document.getElementById("app");
   const _pk = el.getAttribute("data-user-pk");
+  const connectionsUrl = el.getAttribute("data-connections-url");
   console.debug("returning " + _pk);
-  return { _pk };
+  return { _pk, connectionsUrl };
 }
 new EditProfile({ propsData: extractParams() }).$mount("#app");


### PR DESCRIPTION
- Profile edit form redirects to /accounts/social/connections as a central form (which now correctly uses POST) for managing account connections which looks like:
![Screenshot from 2023-02-27 12-53-12](https://user-images.githubusercontent.com/46429375/221673708-d004dae4-e254-44f4-96cf-ab1de4c58146.png)
alternatively, could render the direct links in the template before mounting the vue component form

- errors are now display properly in the connections page instead of rendering a method
- links to password reset page when trying to remove a lone connection from an account with no password set