### PR TITLE
Fix markdown editor + resources blocked by CSP

### DIFF
--- a/django/core/settings/defaults.py
+++ b/django/core/settings/defaults.py
@@ -160,7 +160,7 @@ CSP_SCRIPT_SRC = (
     "https://*.comses.net",
     "'unsafe-eval'",  # unsafe-eval only for dev mode
 )
-
+CSP_CONNECT_SRC = ("'self'", "localhost:*", "ws:", "api.ror.org")
 CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com", "localhost:*")
 CSP_STYLE_SRC = (
     "'self'",

--- a/django/core/settings/defaults.py
+++ b/django/core/settings/defaults.py
@@ -162,7 +162,13 @@ CSP_SCRIPT_SRC = (
 )
 
 CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com", "localhost:*")
-CSP_STYLE_SRC = ("'self'", "fonts.googleapis.com", "localhost:*", "'unsafe-inline'")
+CSP_STYLE_SRC = (
+    "'self'",
+    "cdnjs.cloudflare.com",
+    "fonts.googleapis.com",
+    "localhost:*",
+    "'unsafe-inline'",
+)
 CSP_IMG_SRC = ("'self'", "data:", "localhost:*", "i.ytimg.com")
 CSP_FRAME_SRC = (
     "'self'",

--- a/django/core/settings/defaults.py
+++ b/django/core/settings/defaults.py
@@ -160,12 +160,20 @@ CSP_SCRIPT_SRC = (
     "https://*.comses.net",
     "'unsafe-eval'",  # unsafe-eval only for dev mode
 )
-CSP_CONNECT_SRC = ("'self'", "localhost:*", "ws:", "api.ror.org")
+CSP_CONNECT_SRC = (
+    "'self'",
+    "localhost:*",
+    "ws:",  # websockets
+    "api.ror.org",  # RoR affiliations dropdown support
+    "cdn.jsdelivr.net",  # for codemirror spell checker
+    "*.comses.net",  # sentry.comses.net
+)
 CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com", "localhost:*")
 CSP_STYLE_SRC = (
     "'self'",
     "cdnjs.cloudflare.com",
     "fonts.googleapis.com",
+    "maxcdn.bootstrapcdn.com",  # font awesome fonts
     "localhost:*",
     "'unsafe-inline'",
 )

--- a/django/core/settings/production.py
+++ b/django/core/settings/production.py
@@ -27,7 +27,6 @@ CSP_DEFAULT_SRC = (
     "'self'",
     "https://comses.net",
     "https://*.comses.net",
-    "www.google-analytics.com",
     "https://hcaptcha.com",
     "https://*.hcaptcha.com",
 )
@@ -41,16 +40,6 @@ CSP_SCRIPT_SRC = (
     "https://*.comses.net",
     "https://hcaptcha.com",
     "https://*.hcaptcha.com",
-)
-
-CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com")
-CSP_STYLE_SRC = (
-    "'self'",
-    "cdnjs.cloudflare.com",
-    "fonts.googleapis.com",
-    "https://hcaptcha.com",
-    "https://*.hcaptcha.com",
-    "'unsafe-inline'",
 )
 CSP_IMG_SRC = ("'self'", "data:", "i.ytimg.com", "www.google-analytics.com")
 CSP_FRAME_SRC = (

--- a/django/core/settings/production.py
+++ b/django/core/settings/production.py
@@ -46,6 +46,7 @@ CSP_SCRIPT_SRC = (
 CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com")
 CSP_STYLE_SRC = (
     "'self'",
+    "cdnjs.cloudflare.com",
     "fonts.googleapis.com",
     "https://hcaptcha.com",
     "https://*.hcaptcha.com",

--- a/django/core/settings/staging.py
+++ b/django/core/settings/staging.py
@@ -62,7 +62,12 @@ CSP_SCRIPT_SRC = (
     "'unsafe-eval'",
 )
 
-CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com")
+CSP_FONT_SRC = (
+    "'self'",
+    "fonts.googleapis.com",
+    "fonts.gstatic.com",
+    "maxcdn.bootstrapcdn.com",
+)
 CSP_STYLE_SRC = (
     "'self'",
     "cdnjs.cloudflare.com",

--- a/django/core/settings/staging.py
+++ b/django/core/settings/staging.py
@@ -54,6 +54,7 @@ CSP_SCRIPT_SRC = (
     "cdnjs.cloudflare.com",
     "browser.sentry-cdn.com",
     "www.googletagmanager.com",
+    "www.google-analytics.com",
     "https://comses.net",
     "https://*.comses.net",
     "https://hcaptcha.com",
@@ -65,6 +66,7 @@ CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com")
 CSP_STYLE_SRC = (
     "'self'",
     "cdnjs.cloudflare.com",
+    "maxcdn.bootstrapcdn.com",
     "fonts.googleapis.com",
     "https://hcaptcha.com",
     "https://*.hcaptcha.com",

--- a/django/core/settings/staging.py
+++ b/django/core/settings/staging.py
@@ -64,6 +64,7 @@ CSP_SCRIPT_SRC = (
 CSP_FONT_SRC = ("'self'", "fonts.googleapis.com", "fonts.gstatic.com")
 CSP_STYLE_SRC = (
     "'self'",
+    "cdnjs.cloudflare.com",
     "fonts.googleapis.com",
     "https://hcaptcha.com",
     "https://*.hcaptcha.com",

--- a/django/core/widgets.py
+++ b/django/core/widgets.py
@@ -7,7 +7,7 @@ class MarkdownTextarea(WidgetWithScript, forms.widgets.Textarea):
         super().__init__(**kwargs)
 
     def render_js_init(self, domId, name, value):
-        return 'simplemdeAttach("{0}");'.format(domId)
+        return 'mdeAttach("{0}");'.format(domId)
 
     def render(self, name, value, attrs=None, renderer=None):
         # The raw content of markupfield needs to extracted for the markdown to display properly

--- a/django/home/models.py
+++ b/django/home/models.py
@@ -33,6 +33,7 @@ from core.discourse import build_discourse_url
 from core.fields import MarkdownField, TutorialMarkdownField
 from core.fs import get_canonical_image
 from core.models import MemberProfile, Platform, Event, Job
+from core.widgets import MarkdownTextarea
 
 # FIXME: should these models be pushed into core..
 from library.models import Codebase, CodebaseRelease, Contributor
@@ -473,7 +474,7 @@ class EducationPage(NavigationMixin, Page):
 
     content_panels = Page.content_panels + [
         FieldPanel("heading"),
-        FieldPanel("summary", widget=forms.Textarea),
+        FieldPanel("summary", widget=MarkdownTextarea),
         InlinePanel("cards", label=_("Tutorial Cards")),
     ]
 
@@ -515,7 +516,7 @@ class TutorialCard(Orderable, ClusterableModel):
     panels = [
         FieldPanel("url"),
         FieldPanel("title"),
-        FieldPanel("summary", widget=forms.Textarea),
+        FieldPanel("summary", widget=MarkdownTextarea),
         FieldPanel("thumbnail_image"),
         FieldPanel("tags"),
     ]

--- a/frontend/src/components/codebase/Edit.vue
+++ b/frontend/src/components/codebase/Edit.vue
@@ -8,16 +8,14 @@
       label="Title (required)"
       help="A short title describing this computational model, limited to 300 characters."
     ></c-input>
-    <c-textarea
+    <c-markdown
       v-model="description"
       :errorMsgs="errors.description"
       :required="config.description"
       help="A summary description of your model similar to an abstract. There is no limit on length but it should be kept as succinct as possible. "
       name="description"
-      ref="descriptionField"
-      rows="3"
       label="Description (required)"
-    ></c-textarea>
+    ></c-markdown>
     <c-textarea
       v-model="replication_text"
       :errorMsgs="errors.replication_text"
@@ -132,12 +130,6 @@ export default class CodebaseEditForm extends createFormValidator(schema) {
       console.log("response: ", response);
       this.state = response.data;
     }
-  }
-
-  public refresh() {
-    // FIXME: this is a pile of dirty hacks on hacks to properly display the CodeMirror content when it's initially hidden in a modal.
-    // ask the description markdown component to refresh itself.
-    // (this.$refs.descriptionField as any).refresh();
   }
 
   public created() {

--- a/frontend/src/components/event/Edit.vue
+++ b/frontend/src/components/event/Edit.vue
@@ -85,15 +85,14 @@
         </c-datepicker>
       </div>
     </div>
-    <c-textarea
+    <c-markdown
       v-model="description"
-      name="description"
       :errorMsgs="errors.description"
       :required="config.description"
-      label="Description"
       help="Detailed information about the event"
-    >
-    </c-textarea>
+      name="description"
+      label="Description"
+    ></c-markdown>
     <c-textarea
       v-model="summary"
       name="summary"

--- a/frontend/src/components/forms/markdown.ts
+++ b/frontend/src/components/forms/markdown.ts
@@ -6,22 +6,22 @@ import "easymde/dist/easymde.min.css";
 @Component({
   template: `<div :class="['form-group', {'child-is-invalid': isInvalid }]">
     <slot name="label" :label="label">
-      <label :class="['form-control-label', requiredClass]"
-        >{{ label }}
-        <small class="ml-1 text-muted"
-          ><a href="https://en.wikipedia.org/wiki/Markdown" target="_blank">Markdown</a> styling is
-          supported</small
-        >
+      <label :class="['form-control-label', requiredClass]">
+        {{ label }}
       </label>
     </slot>
     <vue-easymde
-      @input="handleInput"
+      @update:modelValue="updateValue"
       :configs="configs"
-      :value="value"
+      :modelValue="value"
       ref="markdownEditor"
     ></vue-easymde>
     <div v-if="isInvalid" class="invalid-feedback">{{ errorMessage }}</div>
-    <slot name="help" :help="help"> </slot>
+    <slot name="help">
+      <small :aria-describedby="controlId" class="form-text text-muted">
+        {{ help }}
+      </small>
+    </slot>
   </div>`,
   components: {
     "vue-easymde": VueEasymde,
@@ -34,12 +34,10 @@ export default class Markdown extends BaseControl {
   @Prop()
   public help: string;
 
-  @Prop()
-  public value: string;
-
   get configs() {
     return {
-      placeholder: this.help,
+      placeholder: "Markdown formatting is supported",
+      status: false,
       toolbar: [
         "bold",
         "italic",
@@ -53,11 +51,8 @@ export default class Markdown extends BaseControl {
         "horizontal-rule",
         "link",
         "image",
-        "table",
         "|",
         "preview",
-        "side-by-side",
-        "fullscreen",
         "|",
         "guide",
       ],
@@ -70,11 +65,6 @@ export default class Markdown extends BaseControl {
 
   public refresh() {
     this.easymde.codemirror.refresh();
-  }
-
-  handleInput(value) {
-    console.log("emitting input value: ", value);
-    this.$emit("input", value);
   }
 
   mounted() {

--- a/frontend/src/components/job/Edit.vue
+++ b/frontend/src/components/job/Edit.vue
@@ -9,15 +9,14 @@
       help="A short title describing the job"
     >
     </c-input>
-    <c-textarea
+    <c-markdown
       v-model="description"
-      name="description"
       :errorMsgs="errors.description"
-      label="Description"
-      help="Detailed information about the job"
       :required="config.description"
-    >
-    </c-textarea>
+      help="Detailed information about the job"
+      name="description"
+      label="Description"
+    ></c-markdown>
     <c-textarea
       v-model="summary"
       name="summary"

--- a/frontend/src/components/profile/Edit.vue
+++ b/frontend/src/components/profile/Edit.vue
@@ -98,22 +98,22 @@
       :required="config.email"
       help="Email changes require reverification of your new email address by acknowledging a confirmation email"
     ></c-input>
-    <c-textarea
+    <c-markdown
       v-model="bio"
       name="bio"
       :errorMsgs="errors.bio"
       help="A brief description of your research career"
       label="Biography"
       :required="config.bio"
-    ></c-textarea>
-    <c-textarea
+    ></c-markdown>
+    <c-markdown
       v-model="research_interests"
       name="research_interests"
       :errorMsgs="errors.research_interests"
-      label="Research Interests"
       help="A brief description of your research interests"
+      label="Research Interests"
       :required="config.research_interests"
-    ></c-textarea>
+    ></c-markdown>
     <c-input
       type="url"
       v-model="personal_url"

--- a/frontend/src/styles/_markdown.scss
+++ b/frontend/src/styles/_markdown.scss
@@ -1,5 +1,22 @@
 @import '~simplemde-theme-base/dist/simplemde-theme-base.min.css';
 
+.editor-toolbar {
+  border-radius: 0 !important;
+  &:before {
+    margin-bottom: 0 !important;
+  }
+  &:after {
+    margin-top: 0 !important;
+  }
+  button {
+    color: $input-color;
+  }
+}
+
+.EasyMDEContainer .CodeMirror {
+  border-radius: 0 !important;
+}
+
 // Needed to make full screen mode visible
 .editor-toolbar.fullscreen, .editor-preview-side, .CodeMirror-fullscreen {
   z-index: $zindex-modal;
@@ -16,7 +33,7 @@
 }
 
 .CodeMirror, .CodeMirror-scroll {
-  min-height: 125px;
+  min-height: 200px !important;
 }
 
 .CodeMirror-scroll {


### PR DESCRIPTION
- Adds cloudflare cdn to CSP `'style-src'` to fix https://www.comses.net/events/calendar/ and ror api domain to `connect-src` to fix org search component
- Fixes issues that prevented `easymde` markdown editor (Vue components + wagtail admin) from working 

![Screenshot from 2023-03-02 15-44-08](https://user-images.githubusercontent.com/46429375/222577323-abddf4a5-f016-40cf-9f4e-fa93352533c2.png)
![Screenshot from 2023-03-02 15-46-28](https://user-images.githubusercontent.com/46429375/222577327-2f30491f-ca5b-464b-bbf8-93949bb0a024.png)

resolves comses/planning#89