### PR TITLE
fix: display correct image for codebases in ogp tags

### DIFF
--- a/django/core/jinja2/base.jinja
+++ b/django/core/jinja2/base.jinja
@@ -1,4 +1,4 @@
-{% from "common.jinja" import ogp_tags_base%}
+{% from "common.jinja" import render_ogp_tags%}
 
 {% if not user %}
     {% set user = request.user %}
@@ -291,7 +291,7 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     {% block ogp_tags %}
-    {{ ogp_tags_base() }}
+    {{ render_ogp_tags() }}
     {% endblock ogp_tags %}
     <title>
         {% block title %}CoMSES Net{% endblock %}

--- a/django/core/jinja2/base.jinja
+++ b/django/core/jinja2/base.jinja
@@ -272,6 +272,23 @@
     {% endwith %}
 {% endmacro %}
 
+{% macro ogp_tags_base(url=None, title=None, description=None, image=None) %}
+    <!-- Facebook Meta Tags -->
+    <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
+    <meta property="og:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
+    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:domain" content="comses.net">
+    <meta property="twitter:url" content="{{ url or 'https://www.comses.net/'}}">
+    <meta name="twitter:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
+    <meta name="twitter:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
+    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+{% endmacro %}
+
 <!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
@@ -289,20 +306,8 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)">
-    <meta property="og:description" content="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/">
-    <meta name="twitter:title" content="The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)">
-    <meta name="twitter:description" content="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
-    {% endblock ogp_tags%}
+    {{ ogp_tags_base() }}
+    {% endblock ogp_tags %}
     <title>
         {% block title %}CoMSES Net{% endblock %}
     </title>

--- a/django/core/jinja2/base.jinja
+++ b/django/core/jinja2/base.jinja
@@ -1,4 +1,4 @@
-{% from "common.jinja" import render_ogp_tags%}
+{% from "common.jinja" import render_ogp_tags %}
 
 {% if not user %}
     {% set user = request.user %}
@@ -275,7 +275,7 @@
 {% endmacro %}
 
 <!DOCTYPE html>
-<html lang="en" class="no-js">
+<html lang="en" class="no-js" prefix="og: http://ogp.me/ns#">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -291,7 +291,7 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
     {% block ogp_tags %}
-    {{ render_ogp_tags() }}
+        {{ render_ogp_tags() }}
     {% endblock ogp_tags %}
     <title>
         {% block title %}CoMSES Net{% endblock %}

--- a/django/core/jinja2/base.jinja
+++ b/django/core/jinja2/base.jinja
@@ -1,3 +1,5 @@
+{% from "common.jinja" import ogp_tags_base%}
+
 {% if not user %}
     {% set user = request.user %}
 {% endif %}
@@ -270,23 +272,6 @@
             </p>
         </footer>
     {% endwith %}
-{% endmacro %}
-
-{% macro ogp_tags_base(url=None, title=None, description=None, image=None) %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
-    <meta property="og:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
-    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
-
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="{{ url or 'https://www.comses.net/'}}">
-    <meta name="twitter:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
-    <meta name="twitter:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
-    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
 {% endmacro %}
 
 <!DOCTYPE html>

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -300,3 +300,20 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {% macro format_date(date) %}
 {{ date.strftime('%B %d, %Y %I:%M %p') }}
 {% endmacro %}
+
+{% macro ogp_tags_base(url=None, title=None, description=None, image=None) %}
+    <!-- Facebook Meta Tags -->
+    <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
+    <meta property="og:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
+    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+
+    <!-- Twitter Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta property="twitter:domain" content="comses.net">
+    <meta property="twitter:url" content="{{ url or 'https://www.comses.net/'}}">
+    <meta name="twitter:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
+    <meta name="twitter:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
+    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+{% endmacro %}

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -301,7 +301,7 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {{ date.strftime('%B %d, %Y %I:%M %p') }}
 {% endmacro %}
 
-{% macro ogp_tags_base(url=None, title=None, description=None, image=None) %}
+{% macro render_ogp_tags(url=None, title=None, description=None, image=None) %}
     <!-- Facebook Meta Tags -->
     <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}">
     <meta property="og:type" content="website">

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -302,18 +302,15 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {% endmacro %}
 
 {% macro render_ogp_tags(url=None, title=None, description=None, image=None) %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
-    <meta property="og:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
-    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+    <!-- Open Graph Protocol Tags -->
 
     <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="{{ url or 'https://www.comses.net/'}}">
-    <meta name="twitter:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}">
-    <meta name="twitter:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}">
-    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}">
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@comses" />
+    <meta property="twitter:domain" content="comses.net" />
+    <meta property="og:url" content="{{ url or 'https://www.comses.net/'}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="{{ title or 'The Network for Computational Modeling in the Social and Ecological Sciences (CoMSES Net)'}}" />
+    <meta property="og:description" content="{{ description or 'CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.'}}" />
+    <meta property="og:image" content="{{ image or static('images/logo-comses.png') }}" />
 {% endmacro %}

--- a/django/core/jinja2/core/events/list.jinja
+++ b/django/core/jinja2/core/events/list.jinja
@@ -1,5 +1,5 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, subnav, member_profile_href, search_tag_href, search_bar, ogp_tags_base
+{% from "common.jinja" import list_page, paginator, breadcrumb, subnav, member_profile_href, search_tag_href, search_bar, render_ogp_tags
 %}
 
 
@@ -119,7 +119,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-{{ ogp_tags_base(url="https://www.comses.net/events/", title="Community Events", description="View all events related to CoMSES")}}
+{{ render_ogp_tags(url="https://www.comses.net/events/", title="Community Events", description="View all events related to CoMSES")}}
 {% endblock ogp_tags %}
 
 

--- a/django/core/jinja2/core/events/list.jinja
+++ b/django/core/jinja2/core/events/list.jinja
@@ -1,5 +1,5 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, subnav, member_profile_href, search_tag_href, search_bar
+{% from "common.jinja" import list_page, paginator, breadcrumb, subnav, member_profile_href, search_tag_href, search_bar, ogp_tags_base
 %}
 
 

--- a/django/core/jinja2/core/events/list.jinja
+++ b/django/core/jinja2/core/events/list.jinja
@@ -2,21 +2,6 @@
 {% from "common.jinja" import list_page, paginator, breadcrumb, subnav, member_profile_href, search_tag_href, search_bar
 %}
 
-{% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/events/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Community Events">
-    <meta property="og:description" content="View all events related to CoMSES">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/events/">
-    <meta name="twitter:title" content="Community Events">
-    <meta name="twitter:description" content="View all events related to CoMSES">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
-{% endblock ogp_tags %}
 
 
 {% macro render_event(item, detail_url_name) %}
@@ -100,6 +85,9 @@
 </div>
 {% endmacro %}
 
+
+
+
 {% block title %}Community Events{% endblock %}
 
 {% block introduction %}<h1>Community Events</h1>{% endblock %}
@@ -121,12 +109,19 @@
 {{ pagination_block }}
 {% endblock %}
 
+
+
 {% block content %}
 {{ list_page(__all__, render_event, 'core:event-detail') }}
 {% if count > 10 %}
 {{ pagination_block }}
 {% endif %}
 {% endblock %}
+
+{% block ogp_tags %}
+{{ ogp_tags_base(url="https://www.comses.net/events/", title="Community Events", description="View all events related to CoMSES")}}
+{% endblock ogp_tags %}
+
 
 {% block sidebar %}
 <div id="sidebar"></div>

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, ogp_tags_base %}
 
 {% block title %}{{ title }}{% endblock %}
 

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, ogp_tags_base %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    {{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
+    {{ render_ogp_tags(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -17,21 +17,8 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="{{ title }}">
-    <meta property="og:description" content="{{ summary }}">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta name="twitter:title" content="{{ title }}">
-    <meta name="twitter:description" content="{{ summary }}">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+    {{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
 {% endblock ogp_tags %}
-
 
 {% block content %}
     <div id='discourse-content'>

--- a/django/core/jinja2/core/jobs/list.jinja
+++ b/django/core/jinja2/core/jobs/list.jinja
@@ -1,20 +1,9 @@
 {% extends "search_layout.jinja" %}
 {% from "common.jinja" import list_page, paginator, breadcrumb, member_profile_href, search_tag_href, search_bar %}
 
+
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/jobs/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Community Jobs">
-    <meta property="og:description" content="View all jobs related to CoMSES">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/jobs/">
-    <meta name="twitter:title" content="Community jobs">
-    <meta name="twitter:description" content="View all jobs related to CoMSES">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+{{ ogp_tags_base(url="https://www.comses.net/jobs/", title="Community Jobs", description="View all jobs related to CoMSES")}}
 {% endblock ogp_tags %}
 
 {% macro render_job(item, detail_url_name) %}

--- a/django/core/jinja2/core/jobs/list.jinja
+++ b/django/core/jinja2/core/jobs/list.jinja
@@ -1,5 +1,5 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, member_profile_href, search_tag_href, search_bar %}
+{% from "common.jinja" import list_page, paginator, breadcrumb, member_profile_href, search_tag_href, search_bar, ogp_tags_base %}
 
 
 {% block ogp_tags %}

--- a/django/core/jinja2/core/jobs/list.jinja
+++ b/django/core/jinja2/core/jobs/list.jinja
@@ -1,9 +1,9 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, member_profile_href, search_tag_href, search_bar, ogp_tags_base %}
+{% from "common.jinja" import list_page, paginator, breadcrumb, member_profile_href, search_tag_href, search_bar, render_ogp_tags %}
 
 
 {% block ogp_tags %}
-{{ ogp_tags_base(url="https://www.comses.net/jobs/", title="Community Jobs", description="View all jobs related to CoMSES")}}
+{{ render_ogp_tags(url="https://www.comses.net/jobs/", title="Community Jobs", description="View all jobs related to CoMSES")}}
 {% endblock ogp_tags %}
 
 {% macro render_job(item, detail_url_name) %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -17,19 +17,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="{{ title }}">
-    <meta property="og:description" content="{{ summary }}">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta name="twitter:title" content="{{ title }}">
-    <meta name="twitter:description" content="{{ summary }}">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+    {{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -22,14 +22,14 @@
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ title }}">
     <meta property="og:description" content="{{ summary }}">
-    <meta property="og:image" content="/static/images/logo.png">
+    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="comses.net">
     <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
     <meta name="twitter:title" content="{{ title }}">
     <meta name="twitter:description" content="{{ summary }}">
-    <meta name="twitter:image" content="/static/images/logo.png">
+    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal %}
+{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, ogp_tags_base %}
 
 {% block title %}{{ title }}{% endblock %}
 

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, ogp_tags_base %}
+{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    {{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
+    {{ render_ogp_tags(url=request.build_absolute_uri(absolute_url), title=title, description=summary) }}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/core/jinja2/core/member_profiles/list.jinja
+++ b/django/core/jinja2/core/member_profiles/list.jinja
@@ -1,6 +1,6 @@
 {% extends "search_layout.jinja" %}
 {% from "common.jinja" import item_component, list_page, paginator, breadcrumb, subnav, member_profile_href,
-search_tag_href, search_bar %}
+search_tag_href, search_bar, ogp_tags_base %}
 
 {% block ogp_tags %}
 {{ ogp_tags_base(url="https://www.comses.net/users/", title="Member Profiles", description="View all users related to CoMSES")}}

--- a/django/core/jinja2/core/member_profiles/list.jinja
+++ b/django/core/jinja2/core/member_profiles/list.jinja
@@ -3,19 +3,7 @@
 search_tag_href, search_bar %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/jobs/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Community Jobs">
-    <meta property="og:description" content="View all jobs related to CoMSES">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/jobs/">
-    <meta name="twitter:title" content="Community jobs">
-    <meta name="twitter:description" content="View all jobs related to CoMSES">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+{{ ogp_tags_base(url="https://www.comses.net/users/", title="Member Profiles", description="View all users related to CoMSES")}}
 {% endblock ogp_tags %}
 
 {% macro render_user(member_profile) %}

--- a/django/core/jinja2/core/member_profiles/list.jinja
+++ b/django/core/jinja2/core/member_profiles/list.jinja
@@ -1,9 +1,9 @@
 {% extends "search_layout.jinja" %}
 {% from "common.jinja" import item_component, list_page, paginator, breadcrumb, subnav, member_profile_href,
-search_tag_href, search_bar, ogp_tags_base %}
+search_tag_href, search_bar, render_ogp_tags %}
 
 {% block ogp_tags %}
-{{ ogp_tags_base(url="https://www.comses.net/users/", title="Member Profiles", description="View all users related to CoMSES")}}
+{{ render_ogp_tags(url="https://www.comses.net/users/", title="Member Profiles", description="View all users related to CoMSES")}}
 {% endblock ogp_tags %}
 
 {% macro render_user(member_profile) %}

--- a/django/core/jinja2/core/member_profiles/retrieve.jinja
+++ b/django/core/jinja2/core/member_profiles/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, subnav, affiliation_href, search_tag_btn, render_social_profile_url, ogp_tags_base %}
+{% from "common.jinja" import breadcrumb, subnav, affiliation_href, search_tag_btn, render_social_profile_url, render_ogp_tags %}
 {% from "library/codebases/macros.jinja" import render_codebase_result, render_reviewer_feedback %}
 
 {% block title %}User profile for {{ profile.name }}{% endblock %}
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-{{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=profile.name, description=profile.bio)}}
+{{ render_ogp_tags(url=request.build_absolute_uri(absolute_url), title=profile.name, description=profile.bio)}}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/core/jinja2/core/member_profiles/retrieve.jinja
+++ b/django/core/jinja2/core/member_profiles/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, subnav, affiliation_href, search_tag_btn, render_social_profile_url %}
+{% from "common.jinja" import breadcrumb, subnav, affiliation_href, search_tag_btn, render_social_profile_url, ogp_tags_base %}
 {% from "library/codebases/macros.jinja" import render_codebase_result, render_reviewer_feedback %}
 
 {% block title %}User profile for {{ profile.name }}{% endblock %}

--- a/django/core/jinja2/core/member_profiles/retrieve.jinja
+++ b/django/core/jinja2/core/member_profiles/retrieve.jinja
@@ -15,21 +15,8 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta property="og:type" content="article">
-    <meta property="og:title" content="{{ profile.name }}">
-    <meta property="og:description" content="{{ profile.bio }}">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
-    <meta name="twitter:title" content="{{ profile.name }}">
-    <meta name="twitter:description" content="{{ profile.bio }}">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+{{ ogp_tags_base(url=request.build_absolute_uri(absolute_url), title=profile.name, description=profile.bio)}}
 {% endblock ogp_tags %}
-
 
 {% block content %}
     <div class='row'>

--- a/django/home/jinja2/home/digest.jinja
+++ b/django/home/jinja2/home/digest.jinja
@@ -1,8 +1,8 @@
 {% extends "base.jinja" %}
-{% from "common.jinja" import breadcrumb, subnav, import ogp_tags_base %}
+{% from "common.jinja" import breadcrumb, subnav, import render_ogp_tags %}
 
 {% block ogp_tags %}
-    {{ ogp_tags_base(url="https://www.comses.net/", title="The COMSES Digest", description="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.") }}
+    {{ render_ogp_tags(url="https://www.comses.net/", title="The COMSES Digest", description="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.") }}
 {% endblock ogp_tags %}
 
 

--- a/django/home/jinja2/home/digest.jinja
+++ b/django/home/jinja2/home/digest.jinja
@@ -1,21 +1,10 @@
 {% extends "base.jinja" %}
-{% from "common.jinja" import breadcrumb, subnav %}
+{% from "common.jinja" import breadcrumb, subnav, import ogp_tags_base %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="The CoMSES Digest">
-    <meta property="og:description" content="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/">
-    <meta name="twitter:title" content="The CoMSES Digest">
-    <meta name="twitter:description" content="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
-{% endblock ogp_tags%}
+    {{ ogp_tags_base(url="https://www.comses.net/", title="The COMSES Digest", description="CoMSES Net is an international open research community dedicated to fostering good practices for computational / agent based modeling.") }}
+{% endblock ogp_tags %}
+
 
 {% block title %}CoMSES Digests{% endblock %}
 

--- a/django/home/jinja2/home/education.jinja
+++ b/django/home/jinja2/home/education.jinja
@@ -1,8 +1,8 @@
 {% extends "base.jinja" %}
-{% from "common.jinja" import breadcrumb, ogp_tags_base %}
+{% from "common.jinja" import breadcrumb, render_ogp_tags %}
 
 {% block ogp_tags %}
-    {{ ogp_tags_base(url="https://www.comses.net/", title="CoMSES Net Education", description="CoMSES Net training modules provide guidance on good practices for computational modeling and sharing your work with FAIR principles for research software (FAIR4RS) and FORCE11 Software Citation Principles in mind.") }}
+    {{ render_ogp_tags(url="https://www.comses.net/", title="CoMSES Net Education", description="CoMSES Net training modules provide guidance on good practices for computational modeling and sharing your work with FAIR principles for research software (FAIR4RS) and FORCE11 Software Citation Principles in mind.") }}
 {% endblock ogp_tags %}
 
 {% block title %}{{ page.title }}{% endblock %}

--- a/django/home/jinja2/home/education.jinja
+++ b/django/home/jinja2/home/education.jinja
@@ -1,21 +1,9 @@
 {% extends "base.jinja" %}
-{% from "common.jinja" import breadcrumb %}
+{% from "common.jinja" import breadcrumb, ogp_tags_base %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="CoMSES Net Education">
-    <meta property="og:description" content="CoMSES Net training modules provide guidance on good practices for computational modeling and sharing your work with FAIR principles for research software (FAIR4RS) and FORCE11 Software Citation Principles in mind.">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/">
-    <meta name="twitter:title" content="CoMSES Net Education">
-    <meta name="twitter:description" content="CoMSES Net training modules provide guidance on good practices for computational modeling and sharing your work with FAIR principles for research software (FAIR4RS) and FORCE11 Software Citation Principles in mind.">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
-{% endblock ogp_tags%}
+    {{ ogp_tags_base(url="https://www.comses.net/", title="CoMSES Net Education", description="CoMSES Net training modules provide guidance on good practices for computational modeling and sharing your work with FAIR principles for research software (FAIR4RS) and FORCE11 Software Citation Principles in mind.") }}
+{% endblock ogp_tags %}
 
 {% block title %}{{ page.title }}{% endblock %}
 

--- a/django/library/jinja2/library/codebases/list.jinja
+++ b/django/library/jinja2/library/codebases/list.jinja
@@ -1,5 +1,5 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, search_bar, ogp_tags_base %}
+{% from "common.jinja" import list_page, paginator, breadcrumb, search_bar, render_ogp_tags %}
 {% from "library/codebases/macros.jinja" import render_codebase_result %}
 
 {% block title %}CoMSES Net Computational Model Library{% endblock %}
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    {{ ogp_tags_base(url="https://www.comses.net/codebases/", title="Community Codebases", description="View all codebases related to CoMSES") }}
+    {{ render_ogp_tags(url="https://www.comses.net/codebases/", title="Community Codebases", description="View all codebases related to CoMSES") }}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/library/jinja2/library/codebases/list.jinja
+++ b/django/library/jinja2/library/codebases/list.jinja
@@ -1,5 +1,5 @@
 {% extends "search_layout.jinja" %}
-{% from "common.jinja" import list_page, paginator, breadcrumb, search_bar %}
+{% from "common.jinja" import list_page, paginator, breadcrumb, search_bar, ogp_tags_base %}
 {% from "library/codebases/macros.jinja" import render_codebase_result %}
 
 {% block title %}CoMSES Net Computational Model Library{% endblock %}
@@ -24,19 +24,7 @@
 {% endblock %}
 
 {% block ogp_tags %}
-    <!-- Facebook Meta Tags -->
-    <meta property="og:url" content="https://www.comses.net/codebases/">
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Community Codebases">
-    <meta property="og:description" content="View all codebases related to CoMSES">
-    <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
-    <!-- Twitter Meta Tags -->
-    <meta name="twitter:card" content="summary_large_image">
-    <meta property="twitter:domain" content="comses.net">
-    <meta property="twitter:url" content="https://www.comses.net/codebases/">
-    <meta name="twitter:title" content="Community codebases">
-    <meta name="twitter:description" content="View all codebases related to CoMSES">
-    <meta name="twitter:image" content="{{ static('images/logo-comses.png') }}">
+    {{ ogp_tags_base(url="https://www.comses.net/codebases/", title="Community Codebases", description="View all codebases related to CoMSES") }}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -62,16 +62,16 @@
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ codebase.title }}">
     <meta property="og:description" content="{{ codebase.summarized_description }}">
-    <meta property="og:image" content="{{ codebase.get_featured_image() }}">
+    <meta property="og:image" content="{{ codebase.get_image_urls()[0] }}">
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="comses.net">
     <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
     <meta name="twitter:title" content="{{ codebase.title }}">
     <meta name="twitter:description" content="{{ codebase.summarized_description }}">
-    <meta name="twitter:image" content="{{ codebase.get_featured_image() }}">
+    <meta name="twitter:image" content="{{ codebase.get_image_urls()[0] }}">
 {% endblock ogp_tags %}
-
+x
 {% block content %}
     {# hidden formatted content for discourse crawler #}
     {% if release.live %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -62,8 +62,8 @@
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ codebase.title }}">
     <meta property="og:description" content="{{ codebase.summarized_description }}">
-    {% if codebase.get_image_urls()|length > 0 %}
-    <meta property="og:image" content="{{ codebase.get_image_urls()[0] }}">
+    {% if codebase.featured_images.exists() %}
+        <meta property="og:image" content="{{ codebase.get_featured_rendition_url() }}">
     {% else %}
         <!-- Provide a fallback image URL -->
         <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
@@ -74,8 +74,8 @@
     <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
     <meta name="twitter:title" content="{{ codebase.title }}">
     <meta name="twitter:description" content="{{ codebase.summarized_description }}">
-    {% if codebase.get_image_urls()|length > 0 %}
-    <meta property="twitter:image" content="{{ codebase.get_image_urls()[0] }}">
+    {% if codebase.featured_images.exists() %}
+    <meta property="twitter:image" content="{{ codebase.get_featured_rendition_url() }}">
     {% else %}
         <!-- Provide a fallback image URL -->
         <meta property="twitter:image" content="{{ static('images/logo-comses.png') }}">

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -64,9 +64,11 @@
     <meta property="og:description" content="{{ codebase.summarized_description }}">
     {% if codebase.featured_images.exists() %}
         <meta property="og:image" content="{{ codebase.get_featured_rendition_url() }}">
+        <meta property="twitter:image" content="{{ codebase.get_featured_rendition_url() }}">
     {% else %}
         <!-- Provide a fallback image URL -->
         <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
+        <meta property="twitter:image" content="{{ static('images/logo-comses.png') }}">
     {% endif %}
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
@@ -74,12 +76,6 @@
     <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
     <meta name="twitter:title" content="{{ codebase.title }}">
     <meta name="twitter:description" content="{{ codebase.summarized_description }}">
-    {% if codebase.featured_images.exists() %}
-    <meta property="twitter:image" content="{{ codebase.get_featured_rendition_url() }}">
-    {% else %}
-        <!-- Provide a fallback image URL -->
-        <meta property="twitter:image" content="{{ static('images/logo-comses.png') }}">
-    {% endif %}
 {% endblock ogp_tags %}
 
 {% block content %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -62,16 +62,26 @@
     <meta property="og:type" content="article">
     <meta property="og:title" content="{{ codebase.title }}">
     <meta property="og:description" content="{{ codebase.summarized_description }}">
+    {% if codebase.get_image_urls()|length > 0 %}
     <meta property="og:image" content="{{ codebase.get_image_urls()[0] }}">
+    {% else %}
+        <!-- Provide a fallback image URL -->
+        <meta property="og:image" content="{{ static('images/logo-comses.png') }}">
+    {% endif %}
     <!-- Twitter Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta property="twitter:domain" content="comses.net">
     <meta property="twitter:url" content="{{ request.build_absolute_uri(absolute_url) }}">
     <meta name="twitter:title" content="{{ codebase.title }}">
     <meta name="twitter:description" content="{{ codebase.summarized_description }}">
-    <meta name="twitter:image" content="{{ codebase.get_image_urls()[0] }}">
+    {% if codebase.get_image_urls()|length > 0 %}
+    <meta property="twitter:image" content="{{ codebase.get_image_urls()[0] }}">
+    {% else %}
+        <!-- Provide a fallback image URL -->
+        <meta property="twitter:image" content="{{ static('images/logo-comses.png') }}">
+    {% endif %}
 {% endblock ogp_tags %}
-x
+
 {% block content %}
     {# hidden formatted content for discourse crawler #}
     {% if release.live %}

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -623,7 +623,10 @@ class Codebase(index.Indexed, ClusterableModel):
             except:
                 pass  # image does not exist
         return urls
-
+    
+    def get_featured_rendition_url(self):
+        return self.get_featured_image().get_rendition('max-900x600').url
+    
     def subpath(self, *args):
         return pathlib.Path(self.base_library_dir, *args)
 

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -623,15 +623,15 @@ class Codebase(index.Indexed, ClusterableModel):
             except:
                 pass  # image does not exist
         return urls
-    
+
     def get_featured_rendition_url(self):
-        url = self.get_featured_image().get_rendition('max-900x600').url
+        url = self.get_featured_image().get_rendition("max-900x600").url
 
         if url:
             return url
         else:
             return None
-        
+
     def subpath(self, *args):
         return pathlib.Path(self.base_library_dir, *args)
 

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -625,12 +625,10 @@ class Codebase(index.Indexed, ClusterableModel):
         return urls
 
     def get_featured_rendition_url(self):
-        url = self.get_featured_image().get_rendition("max-900x600").url
-
-        if url:
-            return url
-        else:
-            return None
+        featured_image = self.get_featured_image()
+        if featured_image:
+            return featured_image.get_rendition("max-900x600").url
+        return None
 
     def subpath(self, *args):
         return pathlib.Path(self.base_library_dir, *args)

--- a/django/library/models.py
+++ b/django/library/models.py
@@ -625,8 +625,13 @@ class Codebase(index.Indexed, ClusterableModel):
         return urls
     
     def get_featured_rendition_url(self):
-        return self.get_featured_image().get_rendition('max-900x600').url
-    
+        url = self.get_featured_image().get_rendition('max-900x600').url
+
+        if url:
+            return url
+        else:
+            return None
+        
     def subpath(self, *args):
         return pathlib.Path(self.base_library_dir, *args)
 


### PR DESCRIPTION
- Fixed the image tags in `django/library/jinja2/library/codebases/releases/retrieve.jinja` to display the correct image.

- Fixed image tag in `django/core/jinja2/core/jobs/retrieve.jinja` to the correct syntax. 