### PR TITLE
Add manual "mark spam" button for admins

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The Computational Model Library maintains distinct submission information packag
 Members who participate in this project agree to abide by the [CoMSES Net Code of Conduct](https://github.com/comses/comses.net/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [editors@comses.net](mailto:editors@comses.net).
 
 ## Ways to Contribute to CoMSES Net
-
 Members are encouraged to participate and we welcome contributions of all kinds to our collective effort. Here's how you can contribute:
 
 ### Publish your Model Source Code

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -336,6 +336,32 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {% endif %}
 {% endmacro %}
 
+{% macro mark_spam_confirm_modal(modal_title, identifier, mark_spam_url, csrf_input) %}
+<button type="button" class="btn btn-danger my-1 w-100" data-bs-toggle="modal" data-bs-target="#mark-spam-modal">
+    Mark spam
+</button>
+<div class="modal fade" id="mark-spam-modal" tabindex="-1" aria-labelledby="mark-spam-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="mark-spam-label">{{ modal_title }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Are you sure you want to mark "<b>{{ identifier }}</b>" as spam?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-gray" data-bs-dismiss="modal">Cancel</button>
+                <form method="post" action="{{ mark_spam_url }}">
+                    {{ csrf_input }}
+                    <button type="submit" class="btn btn-danger">Mark as spam</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endmacro %}
+
 {% macro alert_if_deleted(is_deleted, content_type="content") %}
 {% if is_deleted %}
     <div class="alert alert-danger" role="alert">

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -75,6 +75,7 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Event", title, url("core:event-delete", pk=id), csrf_input) }}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -69,6 +69,7 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Job Posting", title, url("core:job-delete", pk=id), csrf_input) }}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam, mark_spam_confirm_modal %}
 {% from "library/review/includes/macros.jinja" import include_review_reminders, confirm_change_closed_modal %}
 
 {% set open_code_badge_png_url = request.build_absolute_uri(static("images/icons/open-code-badge.png")) %}
@@ -465,6 +465,7 @@
         {% endif %}
     {% endwith %}
     {# end has_change_perm #}
+    {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-mark-spam", identifier=codebase.identifier), csrf_input) }}
 {% endif %}
 {% with review=release.get_review() %}
     {% if review %}


### PR DESCRIPTION
Added a manual "Mark spam" button as a template macro for admins to update ModeratedContent (Events, Jobs, Codebases) as spam. Possible further additions might be adding a notes field for users to add further details about the spam submission? Resolves [comses/planning/issues/255](https://github.com/comses/planning/issues/255).

Current appearance on desktop for events:
![image](https://github.com/user-attachments/assets/fea3e704-a97f-49c3-87c4-f187e4bd9f7b)

Please let me know about any feedback on this pull request or the button's functionality.