### PR TITLE
Add mark spam button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The Computational Model Library maintains distinct submission information packag
 Members who participate in this project agree to abide by the [CoMSES Net Code of Conduct](https://github.com/comses/comses.net/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [editors@comses.net](mailto:editors@comses.net).
 
 ## Ways to Contribute to CoMSES Net
-
 Members are encouraged to participate and we welcome contributions of all kinds to our collective effort. Here's how you can contribute:
 
 ### Publish your Model Source Code

--- a/django/core/jinja2/common.jinja
+++ b/django/core/jinja2/common.jinja
@@ -336,6 +336,34 @@ Currently in <em><mark>{{ constants.DEPLOY_ENVIRONMENT }}</mark></em> mode.
 {% endif %}
 {% endmacro %}
 
+{% macro mark_spam_confirm_modal(modal_title, identifier, mark_spam_url, csrf_input) %}
+<button type="button" class="btn btn-danger my-1 w-100" data-bs-toggle="modal" data-bs-target="#mark-spam-modal">
+    Mark spam
+</button>
+<div class="modal fade" id="mark-spam-modal" tabindex="-1" aria-labelledby="mark-spam-label" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h1 class="modal-title fs-5" id="mark-spam-label">{{ modal_title }}</h1>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <form method="post" action="{{ mark_spam_url }}">
+                <div class="modal-body">
+                    <p>Are you sure you want to mark "<b>{{ identifier }}</b>" as spam?</p>
+                    <label for="notes">Any notes about this content for our devs? </label><br>
+                    <textarea class="form-control" id="notes" name="notes" rows=3></textarea><br>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-gray" data-bs-dismiss="modal">Cancel</button>
+                    {{ csrf_input }}
+                    <button type="submit" class="btn btn-danger">Mark as spam</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endmacro %}
+
 {% macro alert_if_deleted(is_deleted, content_type="content") %}
 {% if is_deleted %}
     <div class="alert alert-danger" role="alert">

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -75,7 +75,7 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not is_marked_spam %}
+        {% if can_moderate and not is_marked_spam %}
             {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
         {% endif %}
     {% endif %}

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -75,6 +75,9 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {% if user.is_superuser and not is_marked_spam %}
+            {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
+        {% endif %}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Event", title, url("core:event-delete", pk=id), csrf_input) }}

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -75,12 +75,12 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if can_moderate and not is_marked_spam %}
-            {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
-        {% endif %}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Event", title, url("core:event-delete", pk=id), csrf_input) }}
+    {% endif %}
+    {% if can_moderate and not is_marked_spam %}
+            {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {#{{ share_card(absolute_url) }}#}
 {% endblock %}

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -75,7 +75,7 @@
         <a href="{{ url('core:event-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if user.is_superuser and not is_marked_spam %}
+        {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not is_marked_spam %}
             {{ mark_spam_confirm_modal("Mark spam", title, url("core:event-mark-spam", pk=id), csrf_input) }}
         {% endif %}
     {% endif %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted %}
+{% from "common.jinja" import permission_button_group, breadcrumb, embed_discourse_comments, share_card, member_profile_href, search_tag_href, delete_confirm_modal, render_ogp_tags, alert_if_spam, alert_if_deleted, mark_spam_confirm_modal %}
 
 {% block title %}{{ title }}{% endblock %}
 
@@ -69,6 +69,9 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
+        {% if user.is_superuser and not is_marked_spam %}
+            {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
+        {% endif %}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Job Posting", title, url("core:job-delete", pk=id), csrf_input) }}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -69,7 +69,7 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not is_marked_spam %}
+        {% if can_moderate and not is_marked_spam %}
             {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
         {% endif %}
     {% endif %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -69,7 +69,7 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if user.is_superuser and not is_marked_spam %}
+        {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not is_marked_spam %}
             {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
         {% endif %}
     {% endif %}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -69,12 +69,12 @@
         <a href="{{ url('core:job-edit', pk=id) }}">
             <div class="btn btn-primary my-1 w-100">Edit</div>
         </a>
-        {% if can_moderate and not is_marked_spam %}
-            {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
-        {% endif %}
     {% endif %}
     {% if has_delete_perm %}
         {{ delete_confirm_modal("Delete Job Posting", title, url("core:job-delete", pk=id), csrf_input) }}
+    {% endif %}
+    {% if can_moderate and not is_marked_spam %}
+            {{ mark_spam_confirm_modal("Mark spam", title, url("core:job-mark-spam", pk=id), csrf_input) }}
     {% endif %}
     {# {{ share_card(absolute_url) }} #}
 {% endblock %}

--- a/django/core/mixins.py
+++ b/django/core/mixins.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 
 from .models import SpamModeration
-from .permissions import ViewRestrictedObjectPermissions, MarkSpamPermissions
+from .permissions import ViewRestrictedObjectPermissions, ModeratorPermission
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +270,7 @@ class SpamCatcherViewSetMixin:
                     f"instance {instance} does not have a {field} attribute"
                 )
 
-    @action(detail=True, methods=["post"], permission_classes=[MarkSpamPermissions])
+    @action(detail=True, methods=["post"], permission_classes=[ModeratorPermission])
     def mark_spam(self, request, **kwargs):
         instance = self.get_object()
         self._validate_content_object(instance)

--- a/django/core/mixins.py
+++ b/django/core/mixins.py
@@ -4,13 +4,15 @@ from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
 from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound
 from rest_framework.response import Response
+from rest_framework.decorators import action
 
 from .models import SpamModeration
-from .permissions import ViewRestrictedObjectPermissions
+from .permissions import ViewRestrictedObjectPermissions, MarkSpamPermissions
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +269,30 @@ class SpamCatcherViewSetMixin:
                 raise ValueError(
                     f"instance {instance} does not have a {field} attribute"
                 )
+
+    @action(detail=True, methods=["post"], permission_classes=[MarkSpamPermissions])
+    def mark_spam(self, request, **kwargs):
+        instance = self.get_object()
+        self._validate_content_object(instance)
+        content_type = ContentType.objects.get_for_model(type(instance))
+        notes = request.data.get("notes")
+        spam_moderation, created = SpamModeration.objects.get_or_create(
+            content_type=content_type,
+            object_id=instance.id,
+            defaults={
+                "status": SpamModeration.Status.SPAM,
+                "detection_method": "manual",
+                "reviewer": request.user,
+                "notes": notes,
+            },
+        )
+        if not created:
+            spam_moderation.status = SpamModeration.Status.SPAM
+            spam_moderation.detection_method = "manual"
+            spam_moderation.reviewer = request.user
+            spam_moderation.notes = notes
+            spam_moderation.save()
+        return redirect(instance.get_list_url())
 
     def handle_spam_detection(self, serializer: serializers.Serializer):
         if "spam_context" in serializer.context:

--- a/django/core/mixins.py
+++ b/django/core/mixins.py
@@ -12,7 +12,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 
 from .models import SpamModeration
-from .permissions import ViewRestrictedObjectPermissions, ModeratorPermission
+from .permissions import ViewRestrictedObjectPermissions, ModeratorPermissions
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +270,7 @@ class SpamCatcherViewSetMixin:
                     f"instance {instance} does not have a {field} attribute"
                 )
 
-    @action(detail=True, methods=["post"], permission_classes=[ModeratorPermission])
+    @action(detail=True, methods=["post"], permission_classes=[ModeratorPermissions])
     def mark_spam(self, request, **kwargs):
         instance = self.get_object()
         self._validate_content_object(instance)

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -35,6 +35,7 @@ EXCLUDED_USERNAMES = ("AnonymousUser", "openabm")
 
 class ComsesGroups(Enum):
     ADMIN = "Admins"
+    MODERATOR = "Moderators"
     EDITOR = "Editors"
     FULL_MEMBER = "Full Members"
     REVIEWER = "Reviewers"

--- a/django/core/models.py
+++ b/django/core/models.py
@@ -57,7 +57,14 @@ class ComsesGroups(Enum):
         if _group is None:
             _group = self.group = Group.objects.get(name=self.value)
         return _group
-
+    
+    # can be called like #ComsesGroups.ADMIN.is_group_member(user)
+    def is_group_member(self, user):
+        for member in self.users():
+            if member.username == user.username:
+                return True
+        
+        return False
 
 def get_sentinel_user():
     return get_user_model().get_anonymous()

--- a/django/core/permissions.py
+++ b/django/core/permissions.py
@@ -2,6 +2,8 @@ import logging
 
 from rest_framework import permissions, exceptions
 
+from .models import ComsesGroups
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,11 +54,11 @@ class ViewRestrictedObjectPermissions(ObjectPermissions):
         "DELETE": ["%(app_label)s.delete_%(model_name)s"],
     }
 
-class MarkSpamPermissions(permissions.BasePermission):
+
+class ModeratorPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
         if request.user.is_superuser:
             return True
-        
-        return request.user.groups.filter(name='Moderators').exists()
+        return request.user.groups.filter(name=ComsesGroups.MODERATOR.value).exists()

--- a/django/core/permissions.py
+++ b/django/core/permissions.py
@@ -55,10 +55,9 @@ class ViewRestrictedObjectPermissions(ObjectPermissions):
     }
 
 
-class ModeratorPermission(permissions.BasePermission):
+class ModeratorPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
-        if request.user.is_superuser:
+        if ComsesGroups.MODERATOR.is_group_member(request.user) or request.user.is_superuser:
             return True
-        return request.user.groups.filter(name=ComsesGroups.MODERATOR.value).exists()

--- a/django/core/permissions.py
+++ b/django/core/permissions.py
@@ -56,5 +56,7 @@ class MarkSpamPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
         if not request.user or not request.user.is_authenticated:
             return False
+        if request.user.is_superuser:
+            return True
         
-        return request.user.is_superuser
+        return request.user.groups.filter(name='Moderators').exists()

--- a/django/core/permissions.py
+++ b/django/core/permissions.py
@@ -51,3 +51,10 @@ class ViewRestrictedObjectPermissions(ObjectPermissions):
         "PATCH": ["%(app_label)s.change_%(model_name)s"],
         "DELETE": ["%(app_label)s.delete_%(model_name)s"],
     }
+
+class MarkSpamPermissions(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if not request.user or not request.user.is_authenticated:
+            return False
+        
+        return request.user.is_superuser

--- a/django/core/permissions.py
+++ b/django/core/permissions.py
@@ -57,7 +57,7 @@ class ViewRestrictedObjectPermissions(ObjectPermissions):
 
 class ModeratorPermissions(permissions.BasePermission):
     def has_permission(self, request, view):
-        if not request.user or not request.user.is_authenticated:
-            return False
-        if ComsesGroups.MODERATOR.is_group_member(request.user) or request.user.is_superuser:
-            return True
+        user = request.user
+        if user and user.is_authenticated:
+            return user.is_superuser or ComsesGroups.is_moderator(user)
+        return False

--- a/django/core/view_helpers.py
+++ b/django/core/view_helpers.py
@@ -71,16 +71,17 @@ def retrieve_with_perms(self, request, *args, **kwargs):
 
 
 def add_user_retrieve_perms(instance, data, user):
+    print(user.get_all_permissions())
     data["has_change_perm"] = user.has_perm(
-        "{}.change_{}".format(instance._meta.app_label, instance._meta.model_name),
+        f"{instance._meta.app_label}.change_{instance._meta.model_name}",
         instance,
     )
     data["has_delete_perm"] = user.has_perm(
-        "{}.delete_{}".format(instance._meta.app_label, instance._meta.model_name),
+        f"{instance._meta.app_label}.delete_{instance._meta.model_name}",
         instance,
     )
     data["can_moderate"] = (
         user.is_superuser
-        or user.groups.filter(name=ComsesGroups.MODERATOR.value).exists()
+        or ComsesGroups.MODERATOR.is_group_member(user)
     )
     return data

--- a/django/core/view_helpers.py
+++ b/django/core/view_helpers.py
@@ -80,8 +80,5 @@ def add_user_retrieve_perms(instance, data, user):
         f"{instance._meta.app_label}.delete_{instance._meta.model_name}",
         instance,
     )
-    data["can_moderate"] = (
-        user.is_superuser
-        or ComsesGroups.MODERATOR.is_group_member(user)
-    )
+    data["can_moderate"] = user.is_superuser or ComsesGroups.is_moderator(user)
     return data

--- a/django/core/views.py
+++ b/django/core/views.py
@@ -60,7 +60,7 @@ from .pagination import SmallResultSetPagination
 from .permissions import ObjectPermissions, ViewRestrictedObjectPermissions
 from .discourse import build_discourse_url
 from .view_helpers import (
-    add_change_delete_perms,
+    add_user_retrieve_perms,
     get_search_queryset,
     retrieve_with_perms,
 )
@@ -349,7 +349,7 @@ class MemberProfileViewSet(CommonViewSetMixin, HtmlNoDeleteViewSet):
             .with_featured_images()
             .order_by("-last_modified")
         )
-        add_change_delete_perms(instance, context, accessing_user)
+        add_user_retrieve_perms(instance, context, accessing_user)
         return context
 
 

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -1,5 +1,5 @@
 {% extends "sidebar_layout.jinja" %}
-{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam %}
+{% from "common.jinja" import breadcrumb, embed_discourse_comments, share_card, search_tag_href, member_profile_href, render_ogp_tags, alert_if_spam, mark_spam_confirm_modal %}
 {% from "library/review/includes/macros.jinja" import include_review_reminders, confirm_change_closed_modal %}
 
 {% set open_code_badge_png_url = request.build_absolute_uri(static("images/icons/open-code-badge.png")) %}
@@ -465,6 +465,9 @@
         {% endif %}
     {% endwith %}
     {# end has_change_perm #}
+    {% if user.is_superuser and not codebase.is_marked_spam %}
+        {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-mark-spam", identifier=codebase.identifier), csrf_input) }}
+    {% endif %}
 {% endif %}
 {% with review=release.get_review() %}
     {% if review %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -464,8 +464,7 @@
             {% endif %}
         {% endif %}
     {% endwith %}
-    {# end has_change_perm #}
-    {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not codebase.is_marked_spam %}
+    {% if can_moderate and not codebase.is_marked_spam %}
         {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-mark-spam", identifier=codebase.identifier), csrf_input) }}
     {% endif %}
 {% endif %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -465,7 +465,7 @@
         {% endif %}
     {% endwith %}
     {# end has_change_perm #}
-    {% if user.is_superuser and not codebase.is_marked_spam %}
+    {% if (user.is_superuser or user.groups.filter(name='Moderators').exists()) and not codebase.is_marked_spam %}
         {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-mark-spam", identifier=codebase.identifier), csrf_input) }}
     {% endif %}
 {% endif %}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -464,9 +464,9 @@
             {% endif %}
         {% endif %}
     {% endwith %}
-    {% if can_moderate and not codebase.is_marked_spam %}
+{% endif %}
+{% if can_moderate and not codebase.is_marked_spam %}
         {{ mark_spam_confirm_modal("Mark spam", codebase.title, url("library:codebase-mark-spam", identifier=codebase.identifier), csrf_input) }}
-    {% endif %}
 {% endif %}
 {% with review=release.get_review() %}
     {% if review %}

--- a/django/library/views.py
+++ b/django/library/views.py
@@ -34,7 +34,7 @@ from rest_framework.response import Response
 
 from core.models import MemberProfile
 from core.permissions import ViewRestrictedObjectPermissions
-from core.view_helpers import add_change_delete_perms, get_search_queryset
+from core.view_helpers import add_user_retrieve_perms, get_search_queryset
 from core.mixins import CommonViewSetMixin, SpamCatcherViewSetMixin
 from core.views import (
     FormUpdateView,
@@ -427,7 +427,7 @@ class CodebaseViewSet(SpamCatcherViewSetMixin, CommonViewSetMixin, HtmlNoDeleteV
             return redirect(current_version)
         else:
             serializer = self.get_serializer(instance)
-            data = add_change_delete_perms(instance, serializer.data, request.user)
+            data = add_user_retrieve_perms(instance, serializer.data, request.user)
             return Response(data)
 
 
@@ -632,7 +632,7 @@ class CodebaseReleaseShareViewSet(
         instance = self.get_object()
         if request.accepted_renderer.format == "html":
             perms = {}
-            add_change_delete_perms(instance, perms, request.user)
+            add_user_retrieve_perms(instance, perms, request.user)
             return Response({"release": instance, **perms})
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
@@ -708,10 +708,10 @@ class CodebaseReleaseViewSet(CommonViewSetMixin, NoDeleteViewSet):
         instance = self.get_object()
         if request.accepted_renderer.format == "html":
             perms = {}
-            add_change_delete_perms(instance, perms, request.user)
+            add_user_retrieve_perms(instance, perms, request.user)
             return Response({"release": instance, **perms})
         serializer = self.get_serializer(instance)
-        data = add_change_delete_perms(instance, serializer.data, request.user)
+        data = add_user_retrieve_perms(instance, serializer.data, request.user)
         return Response(data)
 
     def get_queryset(self):


### PR DESCRIPTION
Adds mark_spam_confirm_modal in core folder to be implemented for Events, Jobs, Codebases. Essentially resolves comses/planning/issues/255, however improvements in UX and further functionalities are still possible.

Current appearance on desktop for events:
<img width="981" alt="image" src="https://github.com/user-attachments/assets/f2165f73-8125-4d24-8a3d-70eb9f703ecd">
