### PR TITLE
remove relevance in sort order when no query string is present

### DIFF
--- a/django/core/jinja_config.py
+++ b/django/core/jinja_config.py
@@ -131,10 +131,7 @@ def generate_search_form_inputs(query_params):
     Returns:
         list: A list of tuples representing the hidden input fields.
     """
-    # set default ordering to relevance, if it is not specified
-    search_parameters = {
-        "ordering": "relevance",
-    }
+    search_parameters = {}
     if query_params:
         # parse_qsl handles splitting and unquoting key-value pairs and generates a list of tuples
         # do not include the actual query in the query parameters

--- a/django/core/view_helpers.py
+++ b/django/core/view_helpers.py
@@ -87,7 +87,13 @@ def build_search_query(input_text: str) -> SearchQuery:
 
 
 def get_search_queryset(
-    query, queryset, operator="or", fields=None, tags=None, criteria=None
+    query,
+    queryset,
+    operator="or",
+    fields=None,
+    tags=None,
+    criteria=None,
+    order_by_relevance=False,
 ):
     search_backend = get_search_backend()
 
@@ -132,11 +138,6 @@ def get_search_queryset(
     Set up order by relevance override for search
     other sort orders are handled by SmallResultSetPagination filtering and SORT_BY_FILTERS
     """
-    order_by_relevance = False
-    if "ordering" in criteria:
-        sort_order = criteria.pop("ordering")
-        if sort_order == "relevance":
-            order_by_relevance = True
     """
     Filter queryset
     """

--- a/django/library/views.py
+++ b/django/library/views.py
@@ -401,8 +401,14 @@ class CodebaseFilter(filters.BaseFilterBackend):
             # qs += " ".join(programming_languages)
 
         # set order by relevance if there's a query string and no explicit ordering requested
-        order_by_relevance = qs and not ordering
-        return get_search_queryset(qs, queryset, tags=tags, criteria=criteria, order_by_relevance=order_by_relevance)
+        order_by_relevance = qs and (not ordering or ordering == "relevance")
+        return get_search_queryset(
+            qs,
+            queryset,
+            tags=tags,
+            criteria=criteria,
+            order_by_relevance=order_by_relevance,
+        )
 
 
 class CodebaseViewSet(SpamCatcherViewSetMixin, CommonViewSetMixin, HtmlNoDeleteViewSet):

--- a/django/library/views.py
+++ b/django/library/views.py
@@ -400,13 +400,9 @@ class CodebaseFilter(filters.BaseFilterBackend):
             # or we could include the PL in the query
             # qs += " ".join(programming_languages)
 
-        default_ordering = "-first_published_at"
-        if ordering:
-            criteria.update(ordering=ordering if qs else default_ordering)
-        else:
-            # set default ordering for search when ordering is not specified
-            criteria.update(ordering="relevance" if qs else default_ordering)
-
+        # default ordering is relevance if there's a query string, otherwise "-first_published_at"
+        default_ordering = "relevance" if qs else "-first_published_at"
+        criteria.update(ordering=ordering if ordering else default_ordering)
         return get_search_queryset(qs, queryset, tags=tags, criteria=criteria)
 
 

--- a/django/library/views.py
+++ b/django/library/views.py
@@ -399,12 +399,13 @@ class CodebaseFilter(filters.BaseFilterBackend):
             criteria.update(id__in=codebases.values_list("id", flat=True))
             # or we could include the PL in the query
             # qs += " ".join(programming_languages)
+
+        default_ordering = "-first_published_at"
         if ordering:
-            criteria.update(ordering=ordering)
+            criteria.update(ordering=ordering if qs else default_ordering)
         else:
-            if qs:
-                # set default ordering for search when ordering is not specified
-                criteria.update(ordering="relevance")
+            # set default ordering for search when ordering is not specified
+            criteria.update(ordering="relevance" if qs else default_ordering)
 
         return get_search_queryset(qs, queryset, tags=tags, criteria=criteria)
 

--- a/django/library/views.py
+++ b/django/library/views.py
@@ -400,10 +400,9 @@ class CodebaseFilter(filters.BaseFilterBackend):
             # or we could include the PL in the query
             # qs += " ".join(programming_languages)
 
-        # default ordering is relevance if there's a query string, otherwise "-first_published_at"
-        default_ordering = "relevance" if qs else "-first_published_at"
-        criteria.update(ordering=ordering if ordering else default_ordering)
-        return get_search_queryset(qs, queryset, tags=tags, criteria=criteria)
+        # set order by relevance if there's a query string and no explicit ordering requested
+        order_by_relevance = qs and not ordering
+        return get_search_queryset(qs, queryset, tags=tags, criteria=criteria, order_by_relevance=order_by_relevance)
 
 
 class CodebaseViewSet(SpamCatcherViewSetMixin, CommonViewSetMixin, HtmlNoDeleteViewSet):

--- a/frontend/src/apps/codebase_list.ts
+++ b/frontend/src/apps/codebase_list.ts
@@ -8,11 +8,20 @@ import { extractDataParams } from "@/util";
 const props = extractDataParams("sidebar", ["languageFacets"]);
 createApp(CodebaseListSidebar, props).mount("#sidebar");
 
-createApp(SortBy, {
-  sortOptions: [
-    { value: "relevance", label: "Relevance" },
-    { value: "-first_published_at", label: "Publish date: newest" },
-    { value: "first_published_at", label: "Publish date: oldest" },
-    { value: "-last_modified", label: "Recently Modified" },
-  ],
-}).mount("#sortby");
+// Function to check if 'query' exists and is not empty
+function hasQueryParam(param: string) {
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(param);
+  return value !== null && value.trim() !== "";
+}
+
+const relevanceOption = hasQueryParam("query") ? [{ value: "relevance", label: "Relevance" }] : [];
+
+const sortOptions = [
+  ...relevanceOption,
+  { value: "-first_published_at", label: "Publish date: newest" },
+  { value: "first_published_at", label: "Publish date: oldest" },
+  { value: "-last_modified", label: "Recently Modified" },
+];
+
+createApp(SortBy, { sortOptions }).mount("#sortby");

--- a/frontend/src/apps/codebase_list.ts
+++ b/frontend/src/apps/codebase_list.ts
@@ -1,5 +1,6 @@
 import "vite/modulepreload-polyfill"; // Ensure that this is needed based on your project setup
 
+import { isEmpty } from "lodash";
 import { createApp } from "vue";
 import CodebaseListSidebar from "@/components/CodebaseListSidebar.vue";
 import SortBy from "@/components/ListSortBy.vue";
@@ -12,16 +13,16 @@ createApp(CodebaseListSidebar, props).mount("#sidebar");
 function hasQueryParam(param: string) {
   const params = new URLSearchParams(window.location.search);
   const value = params.get(param);
-  return value !== null && value.trim() !== "";
+  return !isEmpty(value);
 }
 
 const relevanceOption = hasQueryParam("query") ? [{ value: "relevance", label: "Relevance" }] : [];
 
 const sortOptions = [
   ...relevanceOption,
-  { value: "-first_published_at", label: "Publish date: newest" },
-  { value: "first_published_at", label: "Publish date: oldest" },
-  { value: "-last_modified", label: "Recently Modified" },
+  { value: "-first_published_at", label: "Most recently published" },
+  { value: "first_published_at", label: "Earliest published" },
+  { value: "-last_modified", label: "Recently modified" },
 ];
 
 createApp(SortBy, { sortOptions }).mount("#sortby");

--- a/frontend/src/components/CodebaseListSidebar.vue
+++ b/frontend/src/components/CodebaseListSidebar.vue
@@ -57,6 +57,7 @@
           label="Tags"
           type="Codebase"
           placeholder="Language, framework, etc."
+          :taggable="false"
         />
       </form>
     </template>

--- a/frontend/src/components/CodebaseListSidebar.vue
+++ b/frontend/src/components/CodebaseListSidebar.vue
@@ -120,7 +120,7 @@ const initialFilterValues = {
 onMounted(() => {
   if (props.languageFacets) {
     const localLanguageFacets = { ...props.languageFacets };
-    console.log(localLanguageFacets);
+    // console.log(localLanguageFacets);
     parsedLanguageFacets = Object.entries(localLanguageFacets)
       .sort(([, valueA], [, valueB]) => valueB - valueA) // Sort by value in descending order
       .map(([name, value]) => ({ value: name, label: `${name} (${value})` }));

--- a/frontend/src/components/EventListSidebar.vue
+++ b/frontend/src/components/EventListSidebar.vue
@@ -7,7 +7,7 @@
   >
     <template #form>
       <form @submit="handleSubmit">
-        <TaggerField class="mb-3" name="tags" label="Keywords" type="Event" />
+        <TaggerField class="mb-3" name="tags" label="Keywords" type="Event" :taggable="false" />
         <DatepickerField
           class="mb-3"
           name="submissionDeadlineAfter"

--- a/frontend/src/components/JobListSidebar.vue
+++ b/frontend/src/components/JobListSidebar.vue
@@ -8,7 +8,7 @@
   >
     <template #form>
       <form @submit="handleSubmit">
-        <TaggerField class="mb-3" name="tags" label="Keywords" type="Job" />
+        <TaggerField class="mb-3" name="tags" label="Keywords" type="Job" :taggable="false" />
         <DatepickerField class="mb-3" name="initialPostingAfter" label="Posted after" />
         <DatepickerField name="applicationDeadlineAfter" label="Application deadline after" />
       </form>

--- a/frontend/src/components/ListSidebar.vue
+++ b/frontend/src/components/ListSidebar.vue
@@ -56,7 +56,9 @@ export interface SearchProps {
   clearAllFilters?: () => void;
 }
 
-const props = defineProps<SearchProps>();
+const props = withDefaults(defineProps<SearchProps>(), {
+  isFilterChanged: true,
+});
 
 function handleApplyFilters() {
   isApplyingFiltersLoading.value = true;

--- a/frontend/src/components/ProfileListSidebar.vue
+++ b/frontend/src/components/ProfileListSidebar.vue
@@ -8,7 +8,7 @@
   >
     <template #form>
       <form @submit="handleSubmit">
-        <TaggerField name="tags" label="Keywords" type="Profile" />
+        <TaggerField name="tags" label="Keywords" type="Profile" :taggable="false" />
         <!-- consider adding full member/peer reviewer filter -->
       </form>
     </template>

--- a/frontend/src/components/form/TaggerField.vue
+++ b/frontend/src/components/form/TaggerField.vue
@@ -20,7 +20,7 @@
       :clear-on-select="false"
       :close-on-select="false"
       :options-limit="50"
-      :taggable="true"
+      :taggable="taggable"
       :limit="20"
       @tag="addTag"
       @search-change="fetchMatchingTags"
@@ -66,11 +66,13 @@ export interface TaggerFieldProps {
   help?: string;
   placeholder?: string;
   required?: boolean;
+  taggable?: boolean;
   type?: TagType;
 }
 
 const props = withDefaults(defineProps<TaggerFieldProps>(), {
   type: "",
+  taggable: true,
   placeholder: "Type to add tags",
 });
 


### PR DESCRIPTION
cherry-picked anton's commit 376bc2715b9e8d2e22e2c4e518faee4c587c6d16 from #769 and laid over main instead of the defunct squashed + merged branch