### PR TITLE
fix: disable easymde autosave

### DIFF
--- a/django/core/static/js/mde.attach.js
+++ b/django/core/static/js/mde.attach.js
@@ -21,10 +21,7 @@ function mdeAttach(id) {
         var mde = new EasyMDE({
             element: document.getElementById(id),
             autosave: {
-                enabled: true,
-                delay: 3000,
-                submit_delay: 10000,
-                uniqueId: id,
+                enabled: false,
             },
             toolbar: [
                 "bold", "italic", "heading", "|",


### PR DESCRIPTION
wagtail admin textarea ids are shared between pages so this causes text to be incorrectly cached

resolves comses/planning#279