### PR TITLE
deps: upgrade base image to noble

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ release-version: .env
 	$(ENVREPLACE) TEST_BASIC_AUTH_PASSWORD $$(openssl rand -base64 42) .env
 
 .PHONY: docker-compose.yml
-docker-compose.yml: base.yml dev.yml staging.yml prod.yml config.mk $(PGPASS_PATH) release-version
+docker-compose.yml: base.yml dev.yml staging.yml prod.yml config.mk $(PGPASS_PATH) release-version .env
 	case "$(DEPLOY_ENVIRONMENT)" in \
 	  dev|staging) docker compose -f base.yml -f $(DEPLOY_ENVIRONMENT).yml config > docker-compose.yml;; \
 	  prod) docker compose -f base.yml -f staging.yml -f $(DEPLOY_ENVIRONMENT).yml config > docker-compose.yml;; \
@@ -100,7 +100,7 @@ secrets: $(SECRETS_DIR) $(GENERATED_SECRETS)
 	done
 
 .PHONY: deploy
-deploy: build .env
+deploy: build
 	docker compose pull db redis elasticsearch
 ifneq ($(DEPLOY_ENVIRONMENT),dev)
 	docker compose pull nginx

--- a/deploy/conf/.env.template
+++ b/deploy/conf/.env.template
@@ -1,8 +1,9 @@
 # Docker build
 # UBUNTU_MIRROR=mirror.arizona.edu
+VIRTUAL_ENV=/home/comses/virtualenvs/comses.venv
 UBUNTU_MIRROR=archive.ubuntu.com
 # set PATH defaults for cron execution
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PATH="${VIRTUAL_ENV}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # app settings
 RELEASE_VERSION=
@@ -21,7 +22,7 @@ DISCOURSE_BASE_URL=
 DISCOURSE_API_USERNAME=
 
 # elastic search
-ES_VERSION=7.17.22
+ES_VERSION=7.17.26
 
 # email
 EMAIL_SUBJECT_PREFIX="[CoMSES Net]"

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -1,8 +1,10 @@
-FROM comses/base:jammy
+FROM comses/base:noble
 
 ARG REQUIREMENTS_FILE=requirements-dev.txt
 ARG RUN_SCRIPT=./deploy/dev.sh
 ARG UBUNTU_MIRROR=archive.ubuntu.com
+ENV VIRTUAL_ENV=/home/comses/virtualenvs/comses.venv
+ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -39,6 +41,7 @@ RUN --mount=type=cache,target=/var/lib/apt,sharing=locked \
         unrar-free \
         unzip \
         && update-alternatives --install /usr/bin/python python /usr/bin/python3 1000 \
+        && python -m venv ${VIRTUAL_ENV} \
         && apt-get upgrade -q -y -o Dpkg::Options::="--force-confold" \
         && mkdir -p /etc/service/django \
         && touch /etc/service/django/run /etc/postgresql-backup-pre \

--- a/django/core/tests/test_views.py
+++ b/django/core/tests/test_views.py
@@ -197,7 +197,7 @@ class SpamDetectionTestCase(BaseViewSetTestCase):
         )
         event.refresh_from_db()
         # non-moderators cannot mark content as spam
-        self.assertEquals(response.status_code, 403)
+        self.assertEqual(response.status_code, 403)
         self.assertFalse(event.is_marked_spam)
         # check moderator
         self.client.login(

--- a/django/home/tests/test_metrics.py
+++ b/django/home/tests/test_metrics.py
@@ -39,13 +39,13 @@ class MetricsTestCase(TestCase):
         )
         for chart_data in highcharts_timeseries:
             # 2012 and 2013 should also be 0
-            self.assertEquals(
+            self.assertEqual(
                 tuple(chart_data["data"][0:2]),
                 (0, 0),
                 "2012-13 should be zeroed out",
             )
             # missing year 2016
-            self.assertEquals(
+            self.assertEqual(
                 chart_data["data"][4],
                 0,
                 f"5th entry (2016) should be 0 {chart_data['name']}",
@@ -53,4 +53,4 @@ class MetricsTestCase(TestCase):
             self.assertTrue(
                 chart_data["name"] in OS_NAMES, f"Invalid OS name {chart_data['name']}"
             )
-            self.assertEquals(len(chart_data["data"]), 7, "Should be 7 years of data")
+            self.assertEqual(len(chart_data["data"]), 7, "Should be 7 years of data")

--- a/django/library/tests/test_datacite_api.py
+++ b/django/library/tests/test_datacite_api.py
@@ -50,7 +50,7 @@ class DataCiteApiTest(BaseModelTestCase):
         self.assertTrue(self.api.is_datacite_available())
         release = self.codebase.releases.first()
         log, ok = self.api.mint_public_doi(release)
-        self.assertEquals(log.http_status, 200, "should have successfully minted a DOI")
+        self.assertEqual(log.http_status, 200, "should have successfully minted a DOI")
         self.assertTrue(self.api.doi_matches_pattern(doi))
 
     def test_update_metadata_for_release(self):

--- a/django/library/tests/test_fs.py
+++ b/django/library/tests/test_fs.py
@@ -43,8 +43,8 @@ class ArchiveExtractorTestCase(TestCase):
             fs_api=fs_api,
         )
         logs, level = msgs.serialize()
-        self.assertEquals(level, MessageLevels.warning)
-        self.assertEquals(len(logs), 2)
+        self.assertEqual(level, MessageLevels.warning)
+        self.assertEqual(len(logs), 2)
         self.assertEqual(
             set(
                 fs_api.list(StagingDirectories.originals, FileCategoryDirectories.code)
@@ -77,8 +77,8 @@ class ArchiveExtractorTestCase(TestCase):
                 FileCategoryDirectories.code, content=f, name="invalid.zip"
             )
         logs, level = msgs.serialize()
-        self.assertEquals(level, MessageLevels.error)
-        self.assertEquals(len(logs), 1)
+        self.assertEqual(level, MessageLevels.error)
+        self.assertEqual(len(logs), 1)
 
     @classmethod
     def tearDownClass(cls):

--- a/django/library/tests/test_models.py
+++ b/django/library/tests/test_models.py
@@ -30,11 +30,11 @@ class CodebaseTest(BaseModelTestCase):
         )
 
     def test_base_dir(self):
-        self.assertEquals(
+        self.assertEqual(
             self.c1.base_library_dir,
             pathlib.Path(settings.LIBRARY_ROOT, str(self.c1.uuid)),
         )
-        self.assertEquals(
+        self.assertEqual(
             self.c1.base_git_dir,
             pathlib.Path(settings.REPOSITORY_ROOT, str(self.c1.uuid)),
         )
@@ -43,8 +43,8 @@ class CodebaseTest(BaseModelTestCase):
         release = ReleaseSetup.setUpPublishableDraftRelease(self.c1)
         release.validate_publishable()
         release.publish()
-        self.assertEquals(self.c1.latest_version, release)
-        self.assertEquals(
+        self.assertEqual(self.c1.latest_version, release)
+        self.assertEqual(
             CodebaseRelease.objects.get(
                 codebase=self.c1, version_number=release.version_number
             ),

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -28,7 +28,7 @@ Django==4.2.17
 elasticsearch-dsl>=7.0.0,<8.0.0
 elasticsearch>=7.0.0,<8.0.0
 html2text>=2016.9.19
-jinja2==3.1.4
+jinja2==3.1.5
 jsonschema==4.23.0
 jwt==1.3.1  # needed for allauth
 markdown==3.7

--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -30,6 +30,7 @@ elasticsearch>=7.0.0,<8.0.0
 html2text>=2016.9.19
 jinja2==3.1.4
 jsonschema==4.23.0
+jwt==1.3.1  # needed for allauth
 markdown==3.7
 nltk>=3.8.1,<4.0.0
 numpy==1.26.4


### PR DESCRIPTION
- install python packages into venv as python 3.12 becomes more strict about global package installs

resolves https://github.com/comses/planning/issues/220