### PR TITLE
deps: replace jwt with pyjwt

### DIFF
--- a/django/requirements.txt
+++ b/django/requirements.txt
@@ -30,12 +30,12 @@ elasticsearch>=7.0.0,<8.0.0
 html2text>=2016.9.19
 jinja2==3.1.5
 jsonschema==4.23.0
-jwt==1.3.1  # needed for allauth
 markdown==3.7
 nltk>=3.8.1,<4.0.0
 numpy==1.26.4
 pandas==2.2.2
 psycopg2-binary==2.9.10
+pyjwt[crypto]>=2.4.0,<3.0.0
 pytz==2024.1
 # used for institution -> affiliation data migration
 rapidfuzz==3.9.3


### PR DESCRIPTION
This is the correct one but doesn't actually make any difference currently, since the `jwt` module only gets loaded by the allauth google provider, [which is installed but not used](https://github.com/comses/comses.net/blob/67cda2fb78520a004f9105f72d42f132d5813c50/django/core/settings/defaults.py#L130)