### PR TITLE
fix datacite metadata conversion failing and citation authors out of order

### DIFF
--- a/django/library/models.py
+++ b/django/library/models.py
@@ -1649,6 +1649,11 @@ class CodebaseRelease(index.Indexed, ClusterableModel):
         }
 
     @cached_property
+    def common_metadata(self):
+        """Returns a CommonMetadata object used to build specific metadata objects: for example CodeMeta or DataCite"""
+        return CommonMetadata(self) 
+
+    @cached_property
     def datacite(self):
         if not self.live:
             logger.warning(


### PR DESCRIPTION
the datacite fix is straightforward, just added the property back

the problem with the authors being out of order is that we were 'converting' from a `ReleaseContributor` queryset to a `Contributor` queryset via `id__in=rc_qs.values("contributor_id")` which lost the ordering. This helper with Case/When preserves that order and seems to be a common-enough idiom https://stackoverflow.com/a/37648265