### PR TITLE
fix: harden discourse sync validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,18 @@ This platform manages scientific software artifacts and publication metadata. Th
 - If `make test` fails in WSL with Docker daemon or credential-helper errors, prompt the user to start Docker Desktop for Windows and confirm before retrying
 - Do not change existing behavior without updating or adding tests
 
+## Commit conventions
+
+Use Conventional Commits: `type(scope): description`.
+
+- Choose `type` by the change's primary intent, not the files modified.
+- Prefer the most specific type; use `chore` only when none applies. `style` means formatting-only, not UI/CSS changes.
+- Use a scope only when an established repository area clearly applies; do not invent one.
+- Use an imperative, lowercase description with no trailing period, keeping the subject ≤72 characters.
+- For non-trivial commits, explain what changed and why in the body.
+- Reference issues or PRs in the body or footer when relevant
+
+
 ## Environment and Commands
 
 - Use Docker Compose workflow for local development

--- a/django/core/discourse.py
+++ b/django/core/discourse.py
@@ -188,16 +188,27 @@ def sync_discourse_user(user):
     try:
         response = post_discourse_sso_sync(user)
         response.raise_for_status()
-        data = response.json()
+        _response_data = response.json()
+        sso_record = _response_data.get("single_sign_on_record")
+        sync_successful = bool(
+            _response_data.get("id")
+            and sso_record
+            and sso_record.get("user_id") == _response_data.get("id")
+            and sso_record.get("external_id") == member_profile.short_uuid
+        )
+        if sync_successful:
+            logger.debug(
+                "Successfully synced user %s with discourse: %s", user, sso_record
+            )
+            return True
+        else:
+            logger.error(
+                "Unsuccessful sync for user %s with discourse: %s", user, _response_data
+            )
+
     except (requests.RequestException, ValueError):
-        logger.exception("failed to sync user %s with discourse", user)
-        return False
+        logger.exception("Failed sync request for user %s", user)
 
-    if data.get("success"):
-        logger.debug("synced user %s with discourse: %s", user, data)
-        return True
-
-    logger.error("failed to sync user %s with discourse: %s", user, data)
     return False
 
 

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -21,8 +21,8 @@
 {% endblock ogp_tags %}
 
 {% block meta_description -%}
-  <meta name="author" content="{{get_discourse_username(submitter)}}">
-  <meta name="discourse-username" content="{{get_discourse_username(submitter)}}">
+  <meta name="author" content="{{get_discourse_username(submitter.member_profile)}}">
+  <meta name="discourse-username" content="{{get_discourse_username(submitter.member_profile)}}">
 {% endblock %}
 
 {% block content %}

--- a/django/core/jinja2/core/events/retrieve.jinja
+++ b/django/core/jinja2/core/events/retrieve.jinja
@@ -20,6 +20,11 @@
     {{ render_ogp_tags(request, title=title, description=summary) }}
 {% endblock ogp_tags %}
 
+{% block meta_description -%}
+  <meta name="author" content="{{get_discourse_username(submitter)}}">
+  <meta name="discourse-username" content="{{get_discourse_username(submitter)}}">
+{% endblock %}
+
 {% block content %}
     {{ alert_if_spam(is_marked_spam) }}
     {{ alert_if_deleted(is_deleted, "event") }}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -20,6 +20,11 @@
     {{ render_ogp_tags(request, title=title, description=summary) }}
 {% endblock ogp_tags %}
 
+{% block meta_description -%}
+  <meta name="author" content="{{get_discourse_username(submitter)}}">
+  <meta name="discourse-username" content="{{get_discourse_username(submitter)}}">
+{% endblock %}
+
 {% block content %}
     {{ alert_if_spam(is_marked_spam) }}
     {{ alert_if_deleted(is_deleted, "job") }}

--- a/django/core/jinja2/core/jobs/retrieve.jinja
+++ b/django/core/jinja2/core/jobs/retrieve.jinja
@@ -21,8 +21,8 @@
 {% endblock ogp_tags %}
 
 {% block meta_description -%}
-  <meta name="author" content="{{get_discourse_username(submitter)}}">
-  <meta name="discourse-username" content="{{get_discourse_username(submitter)}}">
+  <meta name="author" content="{{get_discourse_username(submitter.member_profile)}}">
+  <meta name="discourse-username" content="{{get_discourse_username(submitter.member_profile)}}">
 {% endblock %}
 
 {% block content %}

--- a/django/core/jinja_config.py
+++ b/django/core/jinja_config.py
@@ -22,7 +22,7 @@ import logging
 from datetime import datetime
 from urllib.parse import parse_qsl
 
-from core.discourse import get_sanitized_username
+from core.discourse import get_sanitized_username, sanitize_username
 from core.fields import render_sanitized_markdown
 from core.models import ComsesGroups
 from core.serializers import FULL_DATE_FORMAT, FULL_DATETIME_FORMAT
@@ -154,8 +154,14 @@ def should_enable_discourse(is_public: bool):
     return is_public and not settings.DEPLOY_ENVIRONMENT.is_development
 
 
-def get_discourse_username(user) -> str:
-    return get_sanitized_username(user.member_profile)
+def get_discourse_username(member_profile) -> str:
+    # member_profile may be a MemberProfile model instance or a serialized dict
+    # from RelatedMemberProfileSerializer (which includes "username" and "id").
+    if isinstance(member_profile, dict):
+        return sanitize_username(
+            username=member_profile["username"], seed=member_profile["id"]
+        )
+    return get_sanitized_username(member_profile)
 
 
 def librarian_url(user):

--- a/django/core/jinja_config.py
+++ b/django/core/jinja_config.py
@@ -22,6 +22,7 @@ import logging
 from datetime import datetime
 from urllib.parse import parse_qsl
 
+from core.discourse import get_sanitized_username
 from core.fields import render_sanitized_markdown
 from core.models import ComsesGroups
 from core.serializers import FULL_DATE_FORMAT, FULL_DATETIME_FORMAT
@@ -73,6 +74,7 @@ def environment(**options):
             "provider_login_url": provider_login_url,
             "provider_display_name": provider_display_name,
             "get_choices_display": get_choices_display,
+            "get_discourse_username": get_discourse_username,
             "get_download_request_metadata": get_download_request_metadata,
             "markdown": markdown,
             "add_field_css": add_field_css,
@@ -150,6 +152,10 @@ def should_enable_discourse(is_public: bool):
     Model, e.g., Codebase/CodebaseRelease/Event/Job) is public.
     """
     return is_public and not settings.DEPLOY_ENVIRONMENT.is_development
+
+
+def get_discourse_username(user) -> str:
+    return get_sanitized_username(user.member_profile)
 
 
 def librarian_url(user):

--- a/django/home/models.py
+++ b/django/home/models.py
@@ -2,7 +2,6 @@ import logging
 from datetime import date, datetime
 from textwrap import shorten
 
-import requests
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -11,8 +11,10 @@
 
 {% block meta_description -%}
   <meta name="description" content="{{codebase.description.raw|truncate(150)}}">
-  <meta name="author" content="{{get_discourse_username(codebase.submitter)}}">
-  <meta name="discourse-username" content="{{get_discourse_username(codebase.submitter)}}">
+  {% with mp=codebase.submitter.member_profile %}
+    <meta name="author" content="{{get_discourse_username(mp)}}">
+    <meta name="discourse-username" content="{{get_discourse_username(mp)}}">
+  {% endwith %}
 {% endblock %}
 
 {%- block head -%}

--- a/django/library/jinja2/library/codebases/releases/retrieve.jinja
+++ b/django/library/jinja2/library/codebases/releases/retrieve.jinja
@@ -11,6 +11,8 @@
 
 {% block meta_description -%}
   <meta name="description" content="{{codebase.description.raw|truncate(150)}}">
+  <meta name="author" content="{{get_discourse_username(codebase.submitter)}}">
+  <meta name="discourse-username" content="{{get_discourse_username(codebase.submitter)}}">
 {% endblock %}
 
 {%- block head -%}


### PR DESCRIPTION
- validate SSO sync responses before reporting success
- add discourse username metadata to event, job, and codebase pages in the vain hope that it will automagically update discourse forum topic authors